### PR TITLE
fixed #12, Incorrect value for moves in FlxText, FlxTileblock and FlxTilemap

### DIFF
--- a/org/flixel/FlxG.as
+++ b/org/flixel/FlxG.as
@@ -246,7 +246,7 @@ package org.flixel
 		static public function log(Data:Object):void
 		{
 			if((_game != null) && (_game._debugger != null))
-				_game._debugger.log.add((Data == null)?"ERROR: null object":Data.toString());
+				_game._debugger.log.add((Data == null)?"ERROR: null object":((Data is Array)?FlxU.formatArray(Data as Array):Data.toString()));
 		}
 		
 		/**

--- a/org/flixel/FlxG.as
+++ b/org/flixel/FlxG.as
@@ -323,6 +323,18 @@ package org.flixel
 		}
 		
 		/**
+		 * Switch to full-screen display.
+		 */
+		static public function fullscreen():void
+		{
+			FlxG.stage.displayState = "fullScreen";
+			var fsw:uint = FlxG.width*FlxG.camera.zoom;
+			var fsh:uint = FlxG.height*FlxG.camera.zoom;
+			FlxG.camera.x = (FlxG.stage.fullScreenWidth - fsw)/2;
+			FlxG.camera.y = (FlxG.stage.fullScreenHeight - fsh)/2;
+		}
+		
+		/**
 		 * Generates a random number.  Deterministic, meaning safe
 		 * to use if you want to record replays in random environments.
 		 * 

--- a/org/flixel/FlxObject.as
+++ b/org/flixel/FlxObject.as
@@ -275,6 +275,8 @@ package org.flixel
 			height = Height;
 			mass = 1.0;
 			elasticity = 0.0;
+			
+			health = 1;
 
 			immovable = false;
 			moves = true;

--- a/org/flixel/FlxObject.as
+++ b/org/flixel/FlxObject.as
@@ -196,7 +196,7 @@ package org.flixel
 		/**
 		 * Set this to false if you want to skip the automatic motion/movement stuff (see <code>updateMotion()</code>).
 		 * FlxObject and FlxSprite default to true.
-		 * FlxText, FlxTileblock, FlxTilemap and FlxSound default to false.
+		 * FlxText, FlxTileblock, and FlxTilemap default to false.
 		 */
 		public var moves:Boolean;
 		/**

--- a/org/flixel/FlxSprite.as
+++ b/org/flixel/FlxSprite.as
@@ -166,8 +166,6 @@ package org.flixel
 		public function FlxSprite(X:Number=0,Y:Number=0,SimpleGraphic:Class=null)
 		{
 			super(X,Y);
-			
-			health = 1;
 
 			_flashPoint = new Point();
 			_flashRect = new Rectangle();

--- a/org/flixel/FlxText.as
+++ b/org/flixel/FlxText.as
@@ -64,6 +64,7 @@ package org.flixel
 			_regen = true;
 			_shadow = 0;
 			allowCollisions = NONE;
+			moves = false;
 			calcFrame();
 		}
 		

--- a/org/flixel/FlxTileblock.as
+++ b/org/flixel/FlxTileblock.as
@@ -25,6 +25,7 @@ package org.flixel
 			makeGraphic(Width,Height,0,true);
 			active = false;
 			immovable = true;
+			moves = false;
 		}
 		
 		/**

--- a/org/flixel/FlxTilemap.as
+++ b/org/flixel/FlxTilemap.as
@@ -1361,10 +1361,11 @@ package org.flixel
 		 * @param	bitmapData	A Flash <code>BitmapData</code> object, preferably black and white.
 		 * @param	Invert		Load white pixels as solid instead.
 		 * @param	Scale		Default is 1.  Scale of 2 means each pixel forms a 2x2 block of tiles, and so on.
+		 * @param	ColorMap	An array of color values (uint 0xAARRGGBB) in the order they're intended to be assigned as indices
 		 * 
 		 * @return	A comma-separated string containing the level data in a <code>FlxTilemap</code>-friendly format.
 		 */
-		static public function bitmapToCSV(bitmapData:BitmapData,Invert:Boolean=false,Scale:uint=1):String
+		static public function bitmapToCSV(bitmapData:BitmapData,Invert:Boolean=false,Scale:uint=1,ColorMap:Array=null):String
 		{
 			//Import and scale image if necessary
 			if(Scale > 1)
@@ -1390,7 +1391,9 @@ package org.flixel
 				{
 					//Decide if this pixel/tile is solid (1) or not (0)
 					pixel = bitmapData.getPixel(column,row);
-					if((Invert && (pixel > 0)) || (!Invert && (pixel == 0)))
+					if(ColorMap != null)
+						pixel = ColorMap.indexOf(pixel);
+					else if((Invert && (pixel > 0)) || (!Invert && (pixel == 0)))
 						pixel = 1;
 					else
 						pixel = 0;

--- a/org/flixel/FlxTilemap.as
+++ b/org/flixel/FlxTilemap.as
@@ -139,6 +139,7 @@ package org.flixel
 			_tiles = null;
 			_tileObjects = null;
 			immovable = true;
+			moves = false;
 			cameras = null;
 			_debugTileNotSolid = null;
 			_debugTilePartial = null;

--- a/readme.txt
+++ b/readme.txt
@@ -4,8 +4,6 @@ Flixel is an open source game-making library that is completely free for persona
 
 BASIC FEATURES
 =======================================================
-Flixel includes some basic features common to
-many game engines or other game libraries.
 Display thousands of moving objects
 Basic collisions between objects
 Group objects together for simplicity
@@ -25,5 +23,6 @@ Easy object recycling
 
 HISTORY
 =======================================================
-Adam started working on Flixel in March of 2008, and released the first public version in June 2009. Probably the most commonly asked question about Flixel is "where did it come from?" so we've included a short explanation here.
+Adam started working on Flixel in March of 2008, and released the first public version in June 2009. Probably the most commonly asked question about Flixel is "where did it come from?" so we've included a short explanation here:
+
 “I tried a few different times to make a little game engine type thing that would allow me to make retro games. That just seemed like a fun thing to be able to do for fun on a weekend. I tried it in C++/Python/OpenGL right when I left school, maybe 7 years ago? Anyways, it was a failure. Once ActionScript 3 came out, I was able to do some of the pixel-level stuff that I was really interested in. However, by the time I got my hands on AS3, I was more interested in just making little games, and seeing what patterns evolved. I kept making more complex games by reusing the code from the last project, and eventually those parts that I was seeing in every project got moved to their own folder. I think a lot of coders out there have a folder like this on their hard drive somewhere.”

--- a/readme.txt
+++ b/readme.txt
@@ -1,0 +1,29 @@
+ABOUT FLIXEL
+=======================================================
+Flixel is an open source game-making library that is completely free for personal or commercial use. Written entirely in ActionScript 3 by Adam “Atomic” Saltsman, and designed to be used with free development tools, Flixel is easy to learn, extend and customize. Flixel has been used in hundreds of games, including IGF nominees, Adult Swim games, and avant-garde experiments. Many Flixel users make their first game ever in Flixel.
+
+BASIC FEATURES
+=======================================================
+Flixel includes some basic features common to
+many game engines or other game libraries.
+Display thousands of moving objects
+Basic collisions between objects
+Group objects together for simplicity
+Easily generate and emit particles
+Create game levels using tilemaps
+Text display, save games, scrolling
+Mouse & keyboard input
+Math & color utilities
+
+ADVANCED FEATURES
+=======================================================
+Record and play back replays
+Powerful interactive debugger
+Camera system for split screen
+Pathfinding and following
+Easy object recycling
+
+HISTORY
+=======================================================
+Adam started working on Flixel in March of 2008, and released the first public version in June 2009. Probably the most commonly asked question about Flixel is "where did it come from?" so we've included a short explanation here.
+“I tried a few different times to make a little game engine type thing that would allow me to make retro games. That just seemed like a fun thing to be able to do for fun on a weekend. I tried it in C++/Python/OpenGL right when I left school, maybe 7 years ago? Anyways, it was a failure. Once ActionScript 3 came out, I was able to do some of the pixel-level stuff that I was really interested in. However, by the time I got my hands on AS3, I was more interested in just making little games, and seeing what patterns evolved. I kept making more complex games by reusing the code from the last project, and eventually those parts that I was seeing in every project got moved to their own folder. I think a lot of coders out there have a folder like this on their hard drive somewhere.”


### PR DESCRIPTION
The documentation for moves states that it should default to false for FlxText, FlxTileblock and FlxTilemap. I've simply set the value correctly in the constructor of these classes.
