### PR TITLE
Fix issue #171 - Added `super.destroy()` to all overridden `destroy()` methods

### DIFF
--- a/org/flixel/FlxCamera.as
+++ b/org/flixel/FlxCamera.as
@@ -281,6 +281,7 @@ package org.flixel
 			_fxShakeComplete = null;
 			_fxShakeOffset = null;
 			_fill = null;
+			super.destroy();
 		}
 		
 		/**

--- a/org/flixel/FlxGroup.as
+++ b/org/flixel/FlxGroup.as
@@ -81,6 +81,7 @@ package org.flixel
 				members = null;
 			}
 			_sortIndex = null;
+			super.destroy();
 		}
 		
 		/**

--- a/org/flixel/FlxObject.as
+++ b/org/flixel/FlxObject.as
@@ -325,6 +325,7 @@ package org.flixel
 			if(path != null)
 				path.destroy();
 			path = null;
+			super.destroy();
 		}
 		
 		/**

--- a/org/flixel/FlxSprite.as
+++ b/org/flixel/FlxSprite.as
@@ -230,6 +230,8 @@ package org.flixel
 			_matrix = null;
 			_callback = null;
 			framePixels = null;
+			
+			super.destroy();
 		}
 		
 		/**

--- a/org/flixel/plugin/DebugPathDisplay.as
+++ b/org/flixel/plugin/DebugPathDisplay.as
@@ -25,9 +25,9 @@ package org.flixel.plugin
 		 */
 		override public function destroy():void
 		{
-			super.destroy();
 			clear();
 			_paths = null;
+			super.destroy();
 		}
 		
 		/**

--- a/org/flixel/plugin/TimerManager.as
+++ b/org/flixel/plugin/TimerManager.as
@@ -27,6 +27,7 @@ package org.flixel.plugin
 		{
 			clear();
 			_timers = null;
+			super.destroy();
 		}
 		
 		/**

--- a/org/flixel/system/FlxTile.as
+++ b/org/flixel/system/FlxTile.as
@@ -73,9 +73,9 @@ package org.flixel.system
 		 */
 		override public function destroy():void
 		{
-			super.destroy();
 			callback = null;
 			tilemap = null;
+			super.destroy();
 		}
 	}
 }


### PR DESCRIPTION
Fixes GitHub issue #171
https://github.com/AdamAtomic/flixel/issues/171

In some places, `super.destroy()` was not required. For instance, some
classes extended `FlxBasic` which does not have any content in the
`destroy()` method.

However, just to be safe (and in case that function gets populated at a
later date), calling super was added anyway.
