### PR TITLE
Fix issue #214 - `FlxU.formatArray()` includes first element twice

### DIFF
--- a/org/flixel/FlxU.as
+++ b/org/flixel/FlxU.as
@@ -370,7 +370,7 @@ package org.flixel
 			if((AnyArray == null) || (AnyArray.length <= 0))
 				return "";
 			var string:String = AnyArray[0].toString();
-			var i:uint = 0;
+			var i:uint = 1;
 			var l:uint = AnyArray.length;
 			while(i < l)
 				string += ", " + AnyArray[i++].toString();


### PR DESCRIPTION
`FlxU.formatArray()` would include the first element twice:
https://github.com/AdamAtomic/flixel/issues/214
