### PR TITLE
Fix issue #216 - Animation looping problem

### DIFF
--- a/org/flixel/FlxSprite.as
+++ b/org/flixel/FlxSprite.as
@@ -630,7 +630,7 @@ package org.flixel
 		 */
 		public function play(AnimName:String,Force:Boolean=false):void
 		{
-			if(!Force && (_curAnim != null) && (AnimName == _curAnim.name) && (_curAnim.looped || !finished)) return;
+			if(!Force && (_curAnim != null) && (AnimName == _curAnim.name) && (!_curAnim.looped || !finished)) return;
 			_curFrame = 0;
 			_curIndex = 0;
 			_frameTimer = 0;


### PR DESCRIPTION
Non-looping animations now loop properly
https://github.com/AdamAtomic/flixel/issues/216

I'm tired, and there are too many "ands", "ors", and "nots" for me to
check the answer in my head, so I trust Camasthecat's fix. ;)
(and according to @test84, it should be working)
