### PR TITLE
Add `gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,37 @@
+
+### ACTIONSCRIPT ###
+
+# Build and Release Folders
+bin/
+bin-debug/
+bin-release/
+
+# Project property files
+.actionScriptProperties
+.flexProperties
+.settings/
+.project
+
+
+### OS SPECIAL FILES ###
+
+# Windows
+Thumbs.db
+ehthumbs.db
+Desktop.ini
+$RECYCLE.BIN/
+
+# OSX (MAC)
+.DS_Store
+.AppleDouble
+.LSOverride
+Icon
+._*
+.Spotlight-V100
+.Trashes
+
+# Linux
+.*
+!.gitignore
+*~
+


### PR DESCRIPTION
Removes:
- ActionScript IDE project and workspace data
- ActionScript binary folders
- Windows "noise"
- OSX (MAC) "noise"
- Linux hidden and backup files

Closes the following issues:
https://github.com/AdamAtomic/flixel/pull/117
https://github.com/FlixelCommunity/flixel/issues/69
