### PR TITLE
Fixed `FlxTilemap.ray()` result value always null

### DIFF
--- a/org/flixel/FlxTilemap.as
+++ b/org/flixel/FlxTilemap.as
@@ -1278,10 +1278,11 @@ package org.flixel
 					ry = ly + stepY*((q-lx)/stepX);
 					if((ry > tileY) && (ry < tileY + _tileHeight))
 					{
-						if(Result == null)
-							Result = new FlxPoint();
-						Result.x = rx;
-						Result.y = ry;
+						if(Result != null)
+						{
+							Result.x = rx;
+							Result.y = ry;
+						}
 						return false;
 					}
 					
@@ -1293,10 +1294,11 @@ package org.flixel
 					ry = q;
 					if((rx > tileX) && (rx < tileX + _tileWidth))
 					{
-						if(Result == null)
-							Result = new FlxPoint();
-						Result.x = rx;
-						Result.y = ry;
+						if(Result != null)
+						{
+							Result.x = rx;
+							Result.y = ry;
+						}
 						return false;
 					}
 					return true;


### PR DESCRIPTION
See: https://github.com/AdamAtomic/flixel/issues/224#issuecomment-8101791

I believe this issue was caused by the user mistakenly passing in a null pointer. I've just updated the code slightly to make it more obvious how it works, and to remove an unnecessary FlxPoint creation.
