### PR TITLE
Prevent passing `null` to `FlxObject.add()`

### DIFF
--- a/org/flixel/FlxGroup.as
+++ b/org/flixel/FlxGroup.as
@@ -172,6 +172,12 @@ package org.flixel
 		 */
 		public function add(Object:FlxBasic):FlxBasic
 		{
+			if (Object == null)
+			{
+				FlxG.log("WARNING: Cannot add a `null` object to a FlxGroup.");
+				return null;
+			}
+		
 			//Don't bother adding an object twice.
 			if(members.indexOf(Object) >= 0)
 				return Object;


### PR DESCRIPTION
If null is passed, Flixel will log a warning,
and as expected, will return the object passed in (null).

Resolves the following issues:
- https://github.com/FlixelCommunity/flixel/issues/65
- https://github.com/AdamAtomic/flixel/issues/163
