### PR TITLE
Refactor and clean up FlxSound

### DIFF
--- a/org/flixel/FlxSound.as
+++ b/org/flixel/FlxSound.as
@@ -398,11 +398,7 @@ package org.flixel
 			}
 			_position = _channel.position;
 			_channel.stop();
-			if(_looped)
-			{
-				while(_position >= _sound.length)
-					_position -= _sound.length;
-			}
+			
 			if(_position <= 0)
 				_position = 1;
 			_channel = null;

--- a/org/flixel/FlxSound.as
+++ b/org/flixel/FlxSound.as
@@ -300,17 +300,17 @@ package org.flixel
 		 * 
 		 * @param	X		The X position of the sound.
 		 * @param	Y		The Y position of the sound.
-		 * @param	Object	The object you want to track.
+		 * @param	TargetObject	The object you want to track.
 		 * @param	Radius	The maximum distance this sound can travel.
 		 * @param	Pan		Whether the sound should pan in addition to the volume changes (default: true).
 		 * 
 		 * @return	This FlxSound instance (nice for chaining stuff together, if you're into that).
 		 */
-		public function proximity(X:Number,Y:Number,Object:FlxObject,Radius:Number,Pan:Boolean=true):FlxSound
+		public function proximity(X:Number,Y:Number,TargetObject:FlxObject,Radius:Number,Pan:Boolean=true):FlxSound
 		{
 			x = X;
 			y = Y;
-			_target = Object;
+			_target = TargetObject;
 			_radius = Radius;
 			_pan = Pan;
 			return this;

--- a/org/flixel/FlxSound.as
+++ b/org/flixel/FlxSound.as
@@ -502,10 +502,10 @@ package org.flixel
 		 */
 		protected function looped(event:Event=null):void
 		{
-		    if (_channel == null)
-		    	return;
-	        _channel.removeEventListener(Event.SOUND_COMPLETE,looped);
-	        _channel = null;
+			if (_channel == null)
+				return;
+			_channel.removeEventListener(Event.SOUND_COMPLETE,looped);
+			_channel = null;
 			play();
 		}
 
@@ -517,10 +517,10 @@ package org.flixel
 		protected function stopped(event:Event=null):void
 		{
 			if(!_looped)
-	        	_channel.removeEventListener(Event.SOUND_COMPLETE,stopped);
-	        else
-	        	_channel.removeEventListener(Event.SOUND_COMPLETE,looped);
-	        _channel = null;
+				_channel.removeEventListener(Event.SOUND_COMPLETE,stopped);
+			else
+				_channel.removeEventListener(Event.SOUND_COMPLETE,looped);
+			_channel = null;
 			active = false;
 			if(autoDestroy)
 				destroy();


### PR DESCRIPTION
The point was to make `FlxSound` more clear, and to avoid repetitious code (which if I may say so myself, was a great success). See the commits for full changelog.
