### PR TITLE
Fix bug in #overlaps and #overlapsAt that would lead to only the first e...

### DIFF
--- a/org/flixel/FlxObject.as
+++ b/org/flixel/FlxObject.as
@@ -687,6 +687,7 @@ package org.flixel
 				var results:Boolean = false;
 				var i:uint = 0;
 				var members:Array = (ObjectOrGroup as FlxGroup).members;
+				var length:uint = (ObjectOrGroup as FlxGroup).length;
 				while(i < length)
 				{
 					if(overlaps(members[i++],InScreenSpace,Camera))
@@ -738,6 +739,7 @@ package org.flixel
 				var basic:FlxBasic;
 				var i:uint = 0;
 				var members:Array = (ObjectOrGroup as FlxGroup).members;
+				var length:uint = (ObjectOrGroup as FlxGroup).length;
 				while(i < length)
 				{
 					if(overlapsAt(X,Y,members[i++],InScreenSpace,Camera))


### PR DESCRIPTION
...lement of a FlxGroup being checked by using the wrong length variable.

Fixed FlixelCommunity/flixel#9, AdamAtomic/flixel#223
Fixed FlixelCommunity/flixel#54, AdamAtomic/flixel#177
