### PR TITLE
FlxTilemap.ovelaps() not iterating through FlxGroup

### DIFF
--- a/org/flixel/FlxObject.as
+++ b/org/flixel/FlxObject.as
@@ -687,12 +687,17 @@ package org.flixel
 			if(ObjectOrGroup is FlxGroup)
 			{
 				var results:Boolean = false;
+				var basic:FlxBasic;
 				var i:uint = 0;
 				var members:Array = (ObjectOrGroup as FlxGroup).members;
 				while(i < length)
 				{
-					if(overlaps(members[i++],InScreenSpace,Camera))
-						results = true;
+					basic = members[i++] as FlxBasic;
+					if ((basic != null) && basic.exists)
+					{
+						if(overlaps(basic,InScreenSpace,Camera))
+							results = true;
+					}
 				}
 				return results;
 			}
@@ -742,8 +747,12 @@ package org.flixel
 				var members:Array = (ObjectOrGroup as FlxGroup).members;
 				while(i < length)
 				{
-					if(overlapsAt(X,Y,members[i++],InScreenSpace,Camera))
-						results = true;
+					basic = members[i++] as FlxBasic;
+					if((basic != null) && basic.exists)
+					{
+						if(overlapsAt(X,Y,basic,InScreenSpace,Camera))
+							results = true;
+					}
 				}
 				return results;
 			}

--- a/org/flixel/FlxTilemap.as
+++ b/org/flixel/FlxTilemap.as
@@ -825,18 +825,22 @@ package org.flixel
 				var basic:FlxBasic;
 				var i:uint = 0;
 				var members:Array = (ObjectOrGroup as FlxGroup).members;
+				var length:uint = (ObjectOrGroup as FlxGroup).length;
 				while(i < length)
 				{
 					basic = members[i++] as FlxBasic;
-					if(basic is FlxObject)
+					if((basic != null) && basic.exists)
 					{
-						if(overlapsWithCallback(basic as FlxObject))
-							results = true;
-					}
-					else
-					{
-						if(overlaps(basic,InScreenSpace,Camera))
-							results = true;
+						if(basic is FlxObject)
+						{
+							if(overlapsWithCallback(basic as FlxObject))
+								results = true;
+						}
+						else
+						{
+							if(overlaps(basic,InScreenSpace,Camera))
+								results = true;
+						}
 					}
 				}
 				return results;
@@ -867,20 +871,24 @@ package org.flixel
 				var basic:FlxBasic;
 				var i:uint = 0;
 				var members:Array = (ObjectOrGroup as FlxGroup).members;
+				var length:uint = (ObjectOrGroup as FlxGroup).length;
 				while(i < length)
 				{
 					basic = members[i++] as FlxBasic;
-					if(basic is FlxObject)
+					if((basic != null) && basic.exists)
 					{
-						_point.x = X;
-						_point.y = Y;
-						if(overlapsWithCallback(basic as FlxObject,null,false,_point))
-							results = true;
-					}
-					else
-					{
-						if(overlapsAt(X,Y,basic,InScreenSpace,Camera))
-							results = true;
+						if(basic is FlxObject)
+						{
+							_point.x = X;
+							_point.y = Y;
+							if(overlapsWithCallback(basic as FlxObject,null,false,_point))
+								results = true;
+						}
+						else
+						{
+							if(overlapsAt(X,Y,basic,InScreenSpace,Camera))
+								results = true;
+						}
 					}
 				}
 				return results;


### PR DESCRIPTION
Also fixed FlxObject::overlaps/overlapsAt to check for null objects when iterating.
Fixed FlixelCommunity/flixel#39, AdamAtomic/flixel#192
