### PR TITLE
overlapProcessed isn't properly cleared in FlxQuadTree

### DIFF
--- a/org/flixel/system/FlxQuadTree.as
+++ b/org/flixel/system/FlxQuadTree.as
@@ -564,9 +564,11 @@ package org.flixel.system
 				{
 					//Execute callback functions if they exist
 					if((_processingCallback == null) || _processingCallback(_object,checkObject))
+					{
 						overlapProcessed = true;
-					if(overlapProcessed && (_notifyCallback != null))
-						_notifyCallback(_object,checkObject);
+						if(_notifyCallback != null)
+							_notifyCallback(_object, checkObject);
+					}
 				}
 				_iterator = _iterator.next;
 			}


### PR DESCRIPTION
_notifyCallback is now only called if _processingCallback returned true that iteration.

Fixed FlixelCommunity/flixel#29, AdamAtomic/flixel#203
