### PR TITLE
Fix bug in FlxSound.proximity

### DIFF
--- a/org/flixel/FlxSound.as
+++ b/org/flixel/FlxSound.as
@@ -192,6 +192,8 @@ package org.flixel
 				if(radial < 0) radial = 0;
 				if(radial > 1) radial = 1;
 				
+				radial = 1 - radial;
+				
 				if(_pan)
 				{
 					var d:Number = (_target.x-x)/_radius;

--- a/org/flixel/FlxSound.as
+++ b/org/flixel/FlxSound.as
@@ -196,7 +196,7 @@ package org.flixel
 				
 				if(_pan)
 				{
-					var d:Number = (_target.x-x)/_radius;
+					var d:Number = (x-_target.x)/_radius;
 					if(d < -1) d = -1;
 					else if(d > 1) d = 1;
 					_transform.pan = d;


### PR DESCRIPTION
FlxSound.proximity was inverted: the closer the object was, the lower was the volume.
Fix https://github.com/FlixelCommunity/flixel/issues/4, https://github.com/AdamAtomic/flixel/issues/228 .
