### PR TITLE
Crash when streaming MP3's with no ID3 info

### DIFF
--- a/org/flixel/FlxSound.as
+++ b/org/flixel/FlxSound.as
@@ -164,6 +164,8 @@ package org.flixel
 		{
 			kill();
 
+			_sound.removeEventListener(Event.ID3, gotID3);
+			
 			_transform = null;
 			_sound = null;
 			_channel = null;
@@ -532,10 +534,8 @@ package org.flixel
 		protected function gotID3(event:Event=null):void
 		{
 			FlxG.log("got ID3 info!");
-			if(_sound.id3.songName.length > 0)
-				name = _sound.id3.songName;
-			if(_sound.id3.artist.length > 0)
-				artist = _sound.id3.artist;
+			name = _sound.id3.songName;
+			artist = _sound.id3.artist;
 			_sound.removeEventListener(Event.ID3, gotID3);
 		}
 	}


### PR DESCRIPTION
Removed the unnecessary checks for id3.songName/id3.artist length.
Destroy() now removes the id3 eventlistener in case the FlxSound is destroyed before the info is recieved.

Fixed FlixelCommunity/flixel#33, AdamAtomic/flixel#198
