### PR TITLE
Fix FlxObject#(overlaps|overlapsAt) checking only first element of FlxGroup

### DIFF
--- a/org/flixel/FlxObject.as
+++ b/org/flixel/FlxObject.as
@@ -688,11 +688,14 @@ package org.flixel
 			{
 				var results:Boolean = false;
 				var i:uint = 0;
-				var members:Array = (ObjectOrGroup as FlxGroup).members;
+				var group:FlxGroup = ObjectOrGroup as FlxGroup; 
+				var members:Array = group.members;
+				var length:uint = group.length;
 				while(i < length)
 				{
-					if(overlaps(members[i++],InScreenSpace,Camera))
+					if(members[i] && overlaps(members[i],InScreenSpace,Camera))
 						results = true;
+					i++;
 				}
 				return results;
 			}
@@ -739,11 +742,14 @@ package org.flixel
 				var results:Boolean = false;
 				var basic:FlxBasic;
 				var i:uint = 0;
-				var members:Array = (ObjectOrGroup as FlxGroup).members;
+				var group:FlxGroup = ObjectOrGroup as FlxGroup; 
+				var members:Array = group.members;
+				var length:uint = group.length;
 				while(i < length)
 				{
-					if(overlapsAt(X,Y,members[i++],InScreenSpace,Camera))
+					if(members[i] && overlapsAt(X,Y,members[i],InScreenSpace,Camera))
 						results = true;
+					i++;
 				}
 				return results;
 			}

--- a/org/flixel/FlxObject.as
+++ b/org/flixel/FlxObject.as
@@ -688,13 +688,12 @@ package org.flixel
 			{
 				var results:Boolean = false;
 				var i:uint = 0;
-				var basic:FlxBasic;
 				var group:FlxGroup = ObjectOrGroup as FlxGroup; 
 				var members:Array = group.members;
 				var length:uint = group.length;
 				while(i < length)
 				{
-					basic = members[i++] as FlxBasic;
+					var basic:FlxBasic = members[i++] as FlxBasic;
 					if (basic != null && basic.exists && overlaps(basic,InScreenSpace,Camera))
 					{
 						results = true;
@@ -744,14 +743,13 @@ package org.flixel
 			if(ObjectOrGroup is FlxGroup)
 			{
 				var results:Boolean = false;
-				var basic:FlxBasic;
 				var i:uint = 0;
 				var group:FlxGroup = ObjectOrGroup as FlxGroup; 
 				var members:Array = group.members;
 				var length:uint = group.length;
 				while(i < length)
 				{
-					basic = members[i++] as FlxBasic;
+					var basic:FlxBasic = members[i++] as FlxBasic;
 					if(basic != null && basic.exists && overlapsAt(X,Y,basic,InScreenSpace,Camera))
 					{
 						results = true;

--- a/org/flixel/FlxObject.as
+++ b/org/flixel/FlxObject.as
@@ -688,14 +688,18 @@ package org.flixel
 			{
 				var results:Boolean = false;
 				var i:uint = 0;
+				var basic:FlxBasic;
 				var group:FlxGroup = ObjectOrGroup as FlxGroup; 
 				var members:Array = group.members;
 				var length:uint = group.length;
 				while(i < length)
 				{
-					if(members[i] && overlaps(members[i],InScreenSpace,Camera))
+					basic = members[i++] as FlxBasic;
+					if (basic != null && basic.exists && overlaps(basic,InScreenSpace,Camera))
+					{
 						results = true;
-					i++;
+						break;
+					}
 				}
 				return results;
 			}
@@ -747,9 +751,12 @@ package org.flixel
 				var length:uint = group.length;
 				while(i < length)
 				{
-					if(members[i] && overlapsAt(X,Y,members[i],InScreenSpace,Camera))
+					basic = members[i++] as FlxBasic;
+					if(basic != null && basic.exists && overlapsAt(X,Y,basic,InScreenSpace,Camera))
+					{
 						results = true;
-					i++;
+						break;
+					}
 				}
 				return results;
 			}

--- a/org/flixel/FlxObject.as
+++ b/org/flixel/FlxObject.as
@@ -697,7 +697,6 @@ package org.flixel
 					if (basic != null && basic.exists && overlaps(basic,InScreenSpace,Camera))
 					{
 						results = true;
-						break;
 					}
 				}
 				return results;
@@ -753,7 +752,6 @@ package org.flixel
 					if(basic != null && basic.exists && overlapsAt(X,Y,basic,InScreenSpace,Camera))
 					{
 						results = true;
-						break;
 					}
 				}
 				return results;

--- a/org/flixel/FlxTilemap.as
+++ b/org/flixel/FlxTilemap.as
@@ -826,18 +826,22 @@ package org.flixel
 				var basic:FlxBasic;
 				var i:uint = 0;
 				var members:Array = (ObjectOrGroup as FlxGroup).members;
+				var length:uint = (ObjectOrGroup as FlxGroup).length;
 				while(i < length)
 				{
 					basic = members[i++] as FlxBasic;
-					if(basic is FlxObject)
+					if((basic != null) && basic.exists)
 					{
-						if(overlapsWithCallback(basic as FlxObject))
-							results = true;
-					}
-					else
-					{
-						if(overlaps(basic,InScreenSpace,Camera))
-							results = true;
+						if(basic is FlxObject)
+						{
+							if(overlapsWithCallback(basic as FlxObject))
+								results = true;
+						}
+						else
+						{
+							if(overlaps(basic,InScreenSpace,Camera))
+								results = true;
+						}
 					}
 				}
 				return results;
@@ -868,20 +872,30 @@ package org.flixel
 				var basic:FlxBasic;
 				var i:uint = 0;
 				var members:Array = (ObjectOrGroup as FlxGroup).members;
+				var length:uint = (ObjectOrGroup as FlxGroup).length;
 				while(i < length)
 				{
 					basic = members[i++] as FlxBasic;
-					if(basic is FlxObject)
+					if((basic != null) && basic.exists)
 					{
-						_point.x = X;
-						_point.y = Y;
-						if(overlapsWithCallback(basic as FlxObject,null,false,_point))
-							results = true;
-					}
-					else
-					{
-						if(overlapsAt(X,Y,basic,InScreenSpace,Camera))
-							results = true;
+						if(basic is FlxObject)
+						{
+							_point.x = X;
+							_point.y = Y;
+							if(overlapsWithCallback(basic as FlxObject,null,false,_point))
+							{	
+								results = true;
+								break;
+							}
+						}
+						else
+						{
+							if(overlapsAt(X,Y,basic,InScreenSpace,Camera))
+							{	
+								results = true;
+								break;
+							}
+						}
 					}
 				}
 				return results;

--- a/org/flixel/FlxTilemap.as
+++ b/org/flixel/FlxTilemap.as
@@ -885,7 +885,6 @@ package org.flixel
 							if(overlapsWithCallback(basic as FlxObject,null,false,_point))
 							{	
 								results = true;
-								break;
 							}
 						}
 						else
@@ -893,7 +892,6 @@ package org.flixel
 							if(overlapsAt(X,Y,basic,InScreenSpace,Camera))
 							{	
 								results = true;
-								break;
 							}
 						}
 					}


### PR DESCRIPTION
FlxObject#overlaps and FlxObject#overlapsAt had a bug that would lead to only the first element of a FlxGroup being checked. It was happening because the variable "length" was not locally declared, however there was no compiling warns/errors because the Object class has a property named "length".

Fixed FlixelCommunity/flixel#9, AdamAtomic/flixel#223
Fixed FlixelCommunity/flixel#54, AdamAtomic/flixel#177
Fixed FlixelCommunity/flixel#39, AdamAtomic/flixel#192
