### PR TITLE
Add `FlxGroup::revive()`

### DIFF
--- a/org/flixel/FlxGroup.as
+++ b/org/flixel/FlxGroup.as
@@ -559,7 +559,7 @@ package org.flixel
 		}
 		
 		/**
-		 * Calls revive on the group itself and then on thegroup's members.
+		 * Calls revive on the group itself and then on the group's members.
 		 */
 		override public function revive():void
 		{
@@ -571,7 +571,7 @@ package org.flixel
 			while(i < length)
 			{
 				basic = members[i++] as FlxBasic;
-				if((basic != null) && basic.exists)
+				if((basic != null) && !basic.exists)
 					basic.revive();
 			}
 		}

--- a/org/flixel/FlxGroup.as
+++ b/org/flixel/FlxGroup.as
@@ -553,7 +553,27 @@ package org.flixel
 				if((basic != null) && basic.exists)
 					basic.kill();
 			}
+			
+			// Kill the group itself
 			super.kill();
+		}
+		
+		/**
+		 * Calls revive on the group itself and then on thegroup's members.
+		 */
+		override public function revive():void
+		{
+			// Revive the group itself
+			super.revive();
+			
+			var basic:FlxBasic;
+			var i:uint = 0;
+			while(i < length)
+			{
+				basic = members[i++] as FlxBasic;
+				if((basic != null) && basic.exists)
+					basic.revive();
+			}
 		}
 		
 		/**

--- a/org/flixel/FlxGroup.as
+++ b/org/flixel/FlxGroup.as
@@ -571,7 +571,7 @@ package org.flixel
 			while(i < length)
 			{
 				basic = members[i++] as FlxBasic;
-				if((basic != null) && !basic.exists)
+				if((basic != null) && !basic.alive)
 					basic.revive();
 			}
 		}


### PR DESCRIPTION
The FlxGroup will now revive itself, and then all its members.

This is to compliment `FlxGroup::kill()`.

Resolves the following issue:
https://github.com/FlixelCommunity/flixel/issues/30
