### PR TITLE
Fix `FlxSound` fade problems

### DIFF
--- a/org/flixel/FlxSound.as
+++ b/org/flixel/FlxSound.as
@@ -336,7 +336,7 @@ package org.flixel
 		
 			if(ForceRestart)
 			{
-				cleanup(false, true);
+				cleanup(false, true, true);
 			} 
 			else if(playing)
 			{
@@ -368,7 +368,7 @@ package org.flixel
 			
 			_position = _channel.position;
 			_paused = true;
-			cleanup(false, false);
+			cleanup(false, false, false);
 		}
 		
 		/**
@@ -376,7 +376,7 @@ package org.flixel
 		 */
 		public function stop():void
 		{
-			cleanup(autoDestroy, true);
+			cleanup(autoDestroy, true, true);
 		}
 		
 		/**
@@ -502,7 +502,7 @@ package org.flixel
 		 * 
 		 * @param	destroySound		Whether or not to destroy the sound 
 		 */
-		protected function cleanup(destroySound:Boolean, resetPosition:Boolean = true):void
+		protected function cleanup(destroySound:Boolean, resetPosition:Boolean = true, resetFading:Boolean = true):void
 		{
 			if (_channel)
 			{
@@ -511,18 +511,21 @@ package org.flixel
 				_channel = null;
 			}
 			
+			active = false;
+			
 			if (resetPosition)
 			{
 				_position = 0;
 				_paused = false;
 			}
 			
-			active = false;
-			
-			_fadeInTimer = 0;
-			_fadeOutTimer = 0;
-			_fadeTotal = 0;
-			_pauseOnFadeOut = false;
+			if (resetFading)
+			{
+				_fadeInTimer = 0;
+				_fadeOutTimer = 0;
+				_fadeTotal = 0;
+				_pauseOnFadeOut = false;
+			}
 			
 			if (destroySound)
 				destroy();

--- a/org/flixel/FlxSound.as
+++ b/org/flixel/FlxSound.as
@@ -237,12 +237,18 @@ package org.flixel
 			_volumeAdjust = radial*fade;
 			updateTransform();
 			
-			if((_transform.volume > 0) && (_channel != null))
+			if(_transform.volume > 0)
 			{
 				amplitudeLeft = _channel.leftPeak/_transform.volume;
 				amplitudeRight = _channel.rightPeak/_transform.volume;
 				amplitude = (amplitudeLeft+amplitudeRight)*0.5;
 			}
+			else
+			{
+				amplitudeLeft = 0;
+				amplitudeRight = 0;
+				amplitude = 0;			
+			}			
 		}
 		
 		override public function kill():void

--- a/org/flixel/FlxSound.as
+++ b/org/flixel/FlxSound.as
@@ -103,7 +103,7 @@ package org.flixel
 		/**
 		 * Internal flag for what to do when the sound is done fading out.
 		 */
-		protected var _onFadeComplete:Boolean;
+		protected var _onFadeComplete:Function;
 		
 		/**
 		 * The FlxSound constructor gets all the variables initialized, but NOT ready to play a sound yet.

--- a/org/flixel/FlxSound.as
+++ b/org/flixel/FlxSound.as
@@ -339,7 +339,7 @@ package org.flixel
 			}
 			
 			if (_paused)
-				startSound(_position);
+				resume();
 			else
 				startSound(0);
 		}

--- a/org/flixel/FlxSound.as
+++ b/org/flixel/FlxSound.as
@@ -97,25 +97,21 @@ package org.flixel
 		 */
 		protected var _pan:Boolean;
 		/**
-		 * Internal timer used to keep track of requests to fade out the sound playback.
-		 */
-		protected var _fadeOutTimer:Number;
-		/**
-		 * Internal helper for fading out sounds.
-		 */
-		protected var _fadeOutTotal:Number;
-		/**
-		 * Internal flag for whether to pause or stop the sound when it's done fading out.
-		 */
-		protected var _pauseOnFadeOut:Boolean;
-		/**
 		 * Internal timer for fading in the sound playback.
 		 */
 		protected var _fadeInTimer:Number;
 		/**
-		 * Internal helper for fading in sounds.
+		 * Internal timer used to keep track of requests to fade out the sound playback.
 		 */
-		protected var _fadeInTotal:Number;
+		protected var _fadeOutTimer:Number;
+		/**
+		 * Internal helper for fading sounds.
+		 */
+		protected var _fadeTotal:Number;
+		/**
+		 * Internal flag for whether to pause or stop the sound when it's done fading out.
+		 */
+		protected var _pauseOnFadeOut:Boolean;
 		
 		/**
 		 * The FlxSound constructor gets all the variables initialized, but NOT ready to play a sound yet.
@@ -146,11 +142,10 @@ package org.flixel
 			_target = null;
 			_radius = 0;
 			_pan = false;
-			_fadeOutTimer = 0;
-			_fadeOutTotal = 0;
-			_pauseOnFadeOut = false;
 			_fadeInTimer = 0;
-			_fadeInTotal = 0;
+			_fadeOutTimer = 0;
+			_fadeTotal = 0;
+			_pauseOnFadeOut = false;
 			exists = false;
 			active = false;
 			visible = false;
@@ -223,13 +218,13 @@ package org.flixel
 					else
 						stop();
 				}
-				fade = _fadeOutTimer/_fadeOutTotal;
+				fade = _fadeOutTimer/_fadeTotal;
 				if(fade < 0) fade = 0;
 			}
 			else if(_fadeInTimer > 0)
 			{
 				_fadeInTimer -= FlxG.elapsed;
-				fade = _fadeInTimer/_fadeInTotal;
+				fade = _fadeInTimer/_fadeTotal;
 				if(fade < 0) fade = 0;
 				fade = 1 - fade;
 			}
@@ -385,7 +380,7 @@ package org.flixel
 			_pauseOnFadeOut = PauseInstead;
 			_fadeInTimer = 0;
 			_fadeOutTimer = Seconds;
-			_fadeOutTotal = _fadeOutTimer;
+			_fadeTotal = _fadeOutTimer;
 		}
 		
 		/**
@@ -398,7 +393,7 @@ package org.flixel
 		{
 			_fadeOutTimer = 0;
 			_fadeInTimer = Seconds;
-			_fadeInTotal = _fadeInTimer;
+			_fadeTotal = _fadeInTimer;
 			play();
 		}
 		

--- a/org/flixel/FlxSound.as
+++ b/org/flixel/FlxSound.as
@@ -181,7 +181,7 @@ package org.flixel
 		 */
 		override public function update():void
 		{
-			if(_paused)
+			if(!playing)
 				return;
 			
 			_position = _channel.position;
@@ -338,9 +338,8 @@ package org.flixel
 			{
 				cleanup(false, true);
 			} 
-			else if(_channel != null)
+			else if(playing)
 			{
-				// Already playing sound
 				return;
 			}
 			
@@ -364,7 +363,7 @@ package org.flixel
 		 */
 		public function pause():void
 		{
-			if(_channel == null)
+			if(!playing)
 				return;
 			
 			_position = _channel.position;
@@ -406,6 +405,11 @@ package org.flixel
 			_fadeInTimer = Seconds;
 			_fadeTotal = _fadeInTimer;
 			play();
+		}
+		
+		public function get playing():Boolean
+		{
+			return (_channel != null);
 		}
 		
 		/**

--- a/org/flixel/FlxSound.as
+++ b/org/flixel/FlxSound.as
@@ -217,9 +217,14 @@ package org.flixel
 						pause();
 					else
 						stop();
+						
+					fade = 1.0;
 				}
-				fade = _fadeOutTimer/_fadeTotal;
-				if(fade < 0) fade = 0;
+				else
+				{
+					fade = _fadeOutTimer/_fadeTotal;
+					if(fade < 0) fade = 0;
+				}
 			}
 			else if(_fadeInTimer > 0)
 			{
@@ -497,6 +502,11 @@ package org.flixel
 			}
 			
 			active = false;
+			
+			_fadeInTimer = 0;
+			_fadeOutTimer = 0;
+			_fadeTotal = 0;
+			_pauseOnFadeOut = false;
 			
 			if (destroySound)
 				destroy();

--- a/org/flixel/FlxSound.as
+++ b/org/flixel/FlxSound.as
@@ -440,9 +440,12 @@ package org.flixel
 		 */
 		protected function startSound(Position:Number):void
 		{
+			// See https://github.com/FlixelCommunity/flixel/issues/120
+			var numLoops:int = (_looped && (Position == 0)) ? 9999 : 0;
+			
 			_position = Position;
 			_paused = false;
-			_channel = _sound.play(_position, (_looped ? 9999 : 0), _transform);
+			_channel = _sound.play(_position, numLoops, _transform);
 			if(_channel != null)
 			{
 				_channel.addEventListener(Event.SOUND_COMPLETE, stopped);

--- a/org/flixel/FlxSound.as
+++ b/org/flixel/FlxSound.as
@@ -387,6 +387,9 @@ package org.flixel
 		 */
 		public function fadeOut(Seconds:Number,PauseInstead:Boolean=false):void
 		{
+			if (!playing)
+				{ return; }
+		
 			_pauseOnFadeOut = PauseInstead;
 			_fadeInTimer = 0;
 			_fadeOutTimer = Seconds;
@@ -401,6 +404,9 @@ package org.flixel
 		 */
 		public function fadeIn(Seconds:Number):void
 		{
+			if (playing)
+				{ return; }
+		
 			_fadeOutTimer = 0;
 			_fadeInTimer = Seconds;
 			_fadeTotal = _fadeInTimer;

--- a/org/flixel/FlxTween.as
+++ b/org/flixel/FlxTween.as
@@ -1,0 +1,109 @@
+package org.flixel
+{	
+	/**
+	 * Simple class for tweening a simple numerical value from one point to another.
+	 * For more complex operations, please use a dedicated library such as TweenMax.
+	 *
+	 * This class does not use the "global" time to progress the tween, but must 
+	 * manually be incremented with the `progress` property.
+	 * 
+	 * @author	Andreas Renberg (IQAndreas)
+	 */
+	public class FlxTween
+	{
+	
+		/**
+		 * A simple, linear tween (constant motion, with no acceleration).
+		 *
+		 * @param StartValue	The starting value.
+		 * @param EndValue	The end value.
+		 * @param Duration	The total duration of the tween.
+		 * @param Ease	The easing function used by the tween. Any tweening function from TweenMax library or the `fl.transitions.easing` package can be used. Defaults to `FlxTween.linear`.
+		 */
+		public function FlxTween(StartValue:Number, EndValue:Number, Duration:Number, Ease:Function = null)
+		{
+			easingFunction = Ease || FlxTween.linear;
+		
+			//TODO: Verify perameters (such as negative duration, invalid start or end values, etc)
+			startValue = StartValue;
+			totalChange = EndValue - StartValue;
+			duration = Duration;
+			
+			_progress = 0;
+		}
+
+		/**
+		 * The easing function used by the Tween.
+		 */
+		protected var easingFunction:Number;
+		/**
+		 * Internal tracker for the start value of the tween.
+		 */
+		protected var startValue:Number;
+		/**
+		 * Internal tracker for the total change in value in the tween.
+		 */
+		protected var totalChange:Number;
+		/**
+		 * Internal tracker for the duration of the tween.
+		 */
+		protected var duration:Number;
+		/**
+		 * Internal tracker for the progress of the tween.
+		 */
+		protected var _progress:Number;
+		
+		
+		/**
+		 * TODO: ASDoc
+		 */
+		public function get progress():Number
+		{
+			return _progress;
+		}
+		public function set progress(value:Number):void
+		{
+			if (value => duration)
+			{
+				value = duration;
+			}
+			else if (value < 0)
+			{
+				value = 0;
+			}
+			
+			_progress = value;
+		}
+		
+		/**
+		 * TODO: ASDoc
+		 */
+		public function get finished():Boolean
+		{
+			return (_progress >= duration);
+		}
+		
+		/**
+		 * TODO: ASDoc
+		 */
+		public function get value():void
+		{
+			return easingFunction(_progress, startValue, totalChange, duration);
+		}
+		
+		/**
+		 * A simple, linear tween (constant motion, with no acceleration).
+		 *
+		 * @param t	Specifies the current progress, between 0 and duration inclusive.
+		 * @param b	Specifies the starting value.
+		 * @param c	Specifies the total change in the value.
+		 * @param d	Specifies the duration of the motion.
+		 *
+		 * @return	The value of the interpolated property at the specified time.
+		 */
+		public static function linear(t:Number, b:Number, c:Number, d:Number):Number
+		{
+			return b + (c*t)/d;
+		}
+	}
+}

--- a/org/flixel/FlxTween.as
+++ b/org/flixel/FlxTween.as
@@ -22,7 +22,7 @@ package org.flixel
 		 */
 		public function FlxTween(StartValue:Number, EndValue:Number, Duration:Number, Ease:Function = null)
 		{
-			easingFunction = Ease || FlxTween.linear;
+			easingFunction = (Ease != null) ? Ease : FlxTween.linear;
 		
 			//TODO: Verify perameters (such as negative duration, invalid start or end values, etc)
 			startValue = StartValue;
@@ -35,7 +35,7 @@ package org.flixel
 		/**
 		 * The easing function used by the Tween.
 		 */
-		protected var easingFunction:Number;
+		protected var easingFunction:Function;
 		/**
 		 * Internal tracker for the start value of the tween.
 		 */
@@ -63,7 +63,7 @@ package org.flixel
 		}
 		public function set progress(value:Number):void
 		{
-			if (value => duration)
+			if (value >= duration)
 			{
 				value = duration;
 			}
@@ -86,7 +86,7 @@ package org.flixel
 		/**
 		 * TODO: ASDoc
 		 */
-		public function get value():void
+		public function get value():Number
 		{
 			return easingFunction(_progress, startValue, totalChange, duration);
 		}


### PR DESCRIPTION
Fixes a few "fade" problems I forgot to address in the previous pull request.

If the sound is paused or stops, all fade modifiers are reset.
