### PR TITLE
Updated `utils` scripts and added `generate-flixel-swc.sh`

### DIFF
--- a/utils/config
+++ b/utils/config
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# NOTE: These variables are relative to where you are calling the script from,
+#	NOT the location of the script!
+
+SOURCE_CODE_LOCATION="."
+LIBRARY_LOCATION="lib"
+
+SWC_OUTPUT_LOCATION="bin"
+ASDOC_OUTPUT_LOCATION="docs"
+

--- a/utils/flex-sdk
+++ b/utils/flex-sdk
@@ -1,0 +1,49 @@
+#! /bin/sh
+
+if [ $# -eq 0 ]; then
+
+	# GET sdk location
+
+	flex_sdk_location=`git config utils.flex-sdk-home`;
+	
+	if [ ! "$flex_sdk_location" ]; then
+		echo "Flex SDK not set!"
+	elif [ ! -e "$flex_sdk_location" ]; then
+		echo "ERROR: '$flex_sdk_location' does not exist."
+	elif [ ! -e "$flex_sdk_location/flex-sdk-description.xml" ]; then
+		echo "ERROR: '$flex_sdk_location' does not contain a valid SDK."
+	else
+		
+		# All good! Return the path of the SDK
+		echo "$flex_sdk_location"
+		exit 0
+		
+	fi
+	
+	echo "Please set the path to the Flex SDK by running the following command:"
+	echo "	\$ utils/flex-sdk [flex sdk location]"
+	exit 1
+
+
+elif [ $# -eq 1 ]; then
+	
+	# SET sdk location
+	
+	flex_sdk_location=$1
+	
+	if [ ! -e "$flex_sdk_location" ]; then
+		echo "ERROR: '$flex_sdk_location' does not exist."; exit 1;
+	elif [ ! -e "$flex_sdk_location/flex-sdk-description.xml" ]; then
+		echo "ERROR: '$flex_sdk_location' does not contain a valid SDK."; exit 1;
+	else
+		git config utils.flex-sdk-home "$1"
+		echo "Flex SDK set to '$1'"
+		exit 0
+	fi
+	
+else
+	
+	echo "Invalid number of arguments. Pass one argument to set the SDK location, or no arguments to retreive it."
+	exit 2
+
+fi

--- a/utils/flex-sdk
+++ b/utils/flex-sdk
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/bash
 
 if [ $# -eq 0 ]; then
 

--- a/utils/generate-flixel-asdoc.sh
+++ b/utils/generate-flixel-asdoc.sh
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/bash
 
 # NOTE: These variables are relative to where you are calling the script from,
 #	NOT the location of the script!

--- a/utils/generate-flixel-asdoc.sh
+++ b/utils/generate-flixel-asdoc.sh
@@ -2,8 +2,19 @@
 
 # NOTE: These variables are relative to where you are calling the script from,
 #	NOT the location of the script!
-FLEX_SDK_LOCATION="/Applications/Adobe Flash Builder 4 Plug-in/sdks/4.0.0"
 CODE_LOCATION="."
 TARGET_LOCATION="docs"
 
-"$FLEX_SDK_LOCATION"/bin/asdoc -source-path "$CODE_LOCATION" -doc-sources "$CODE_LOCATION" -output "$TARGET_LOCATION"
+FLEX_SDK_LOCATION=`utils/flex-sdk`
+
+if [ $? -eq 0 ];then
+
+	"$FLEX_SDK_LOCATION"/bin/asdoc -source-path "$CODE_LOCATION" -doc-sources "$CODE_LOCATION" -output "$TARGET_LOCATION"
+
+else
+
+	# Echo out the error message from running the script
+	echo "$FLEX_SDK_LOCATION";
+	exit 1;
+
+fi

--- a/utils/generate-flixel-asdoc.sh
+++ b/utils/generate-flixel-asdoc.sh
@@ -1,15 +1,12 @@
 #!/bin/bash
 
-# NOTE: These variables are relative to where you are calling the script from,
-#	NOT the location of the script!
-CODE_LOCATION="."
-TARGET_LOCATION="docs"
+source utils/config
 
 FLEX_SDK_LOCATION=`utils/flex-sdk`
 
 if [ $? -eq 0 ];then
 
-	"$FLEX_SDK_LOCATION"/bin/asdoc -source-path "$CODE_LOCATION" -doc-sources "$CODE_LOCATION" -output "$TARGET_LOCATION"
+	"$FLEX_SDK_LOCATION"/bin/asdoc -source-path "$SOURCE_CODE_LOCATION" -doc-sources "$SOURCE_CODE_LOCATION" -output "$ASDOC_OUTPUT_LOCATION"
 
 else
 

--- a/utils/generate-flixel-swc.sh
+++ b/utils/generate-flixel-swc.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+source utils/config
+
+FLEX_SDK_LOCATION=`utils/flex-sdk`
+
+if [ $? -eq 0 ];then
+
+	# TODO: Error handling if repository is not tagged, or not inside of a repo
+	FLIXEL_VERSION=`git describe`
+	OUTPUT="$SWC_OUTPUT_LOCATION/flixel-$FLIXEL_VERSION.swc"
+
+	"$FLEX_SDK_LOCATION"/bin/compc -source-path="$SOURCE_CODE_LOCATION" -include-sources="$SOURCE_CODE_LOCATION" -library-path+="$LIBRARY_LOCATION" -output="$OUTPUT"
+
+else
+
+	# Echo out the error message from running the script
+	echo "$FLEX_SDK_LOCATION";
+	exit 1;
+
+fi


### PR DESCRIPTION
I'm actually quite proud of this one. The two major changes are:

**Saving the Flex SDK location as a git config setting rather than a changeable variable**
Since I'm assuming everyone doesn't have the Flex SDK in the same location, this allows you to change the value without making the script file "dirty". There is a helper script, so you don't need to remember the exact name of the git config option (in fact, give it a try by running `utils/generate-flixel-asdoc.sh` out of the box and see how helpful the script is!)

**Generate a SWC of Flixel's code**
I much prefer using SWCs, and I was tired of opening FDT every time I wanted to compile Flixel. In addition, the script uses `git describe` to get the current version of Flixel (down to the commit) and names the genreated file accordingly. So, for instance, the last SWC I generated was named `flixel-v2.55-54-g869c823.swc`. 

This allows for incremental builds without over-writing old SWCs. And if we combine this with [a script for automating uploading files to GitHub](https://github.com/IQAndreas/ghup/tree/dev-generate-token)...
