### PR TITLE
Fix FlxGroup sort() crash if it encounters another FlxGroup

### DIFF
--- a/org/flixel/FlxGroup.as
+++ b/org/flixel/FlxGroup.as
@@ -577,9 +577,9 @@ package org.flixel
 			if (_sortCheckIndexExistence == true)
 			{
 				// If the sorting property is missing, place the object at the end of the list.
-				if(!(_sortIndex in Obj1))
+				if(!Obj1 || !(_sortIndex in Obj1))
 					return 1;
-				else if(!(_sortIndex in Obj2))
+				else if(!Obj2 || !(_sortIndex in Obj2))
 					return -1;
 			}
 			if(Obj1[_sortIndex] < Obj2[_sortIndex])

--- a/org/flixel/FlxGroup.as
+++ b/org/flixel/FlxGroup.as
@@ -565,6 +565,12 @@ package org.flixel
 		 */
 		protected function sortHandler(Obj1:FlxBasic,Obj2:FlxBasic):int
 		{
+			// If the sorting property is missing, place the object at the end of the list.
+			if(!Obj1.hasOwnProperty(_sortIndex))
+				return 1;
+			else if(!Obj2.hasOwnProperty(_sortIndex))
+				return -1;
+			
 			if(Obj1[_sortIndex] < Obj2[_sortIndex])
 				return _sortOrder;
 			else if(Obj1[_sortIndex] > Obj2[_sortIndex])

--- a/org/flixel/FlxGroup.as
+++ b/org/flixel/FlxGroup.as
@@ -47,6 +47,10 @@ package org.flixel
 		 * Helper for sort.
 		 */
 		protected var _sortOrder:int;
+		/**
+		 * Helper for sort.
+		 */
+		protected var _sortCheckIndexExistence:Boolean;
 
 		/**
 		 * Constructor
@@ -309,14 +313,19 @@ package org.flixel
 		 * <code>myGroup.sort("y",ASCENDING)</code> at the bottom of your
 		 * <code>FlxState.update()</code> override.  To sort all existing objects after
 		 * a big explosion or bomb attack, you might call <code>myGroup.sort("exists",DESCENDING)</code>.
+		 * If you are sure every object in the group has the sorting property you want to sort on, then you
+		 * might call <code>sort()</code> passing <code>false</code> as the third parameter which disables
+		 * the index existence check, boosting the sorting performance.
 		 * 
 		 * @param	Index	The <code>String</code> name of the member variable you want to sort on.  Default value is "y".
-		 * @param	Order	A <code>FlxGroup</code> constant that defines the sort order.  Possible values are <code>ASCENDING</code> and <code>DESCENDING</code>.  Default value is <code>ASCENDING</code>.  
+		 * @param	Order	A <code>FlxGroup</code> constant that defines the sort order.  Possible values are <code>ASCENDING</code> and <code>DESCENDING</code>.  Default value is <code>ASCENDING</code>.
+		 * @param	CheckIndexExistence	Whether the method should check if group members have the sorting property you want to sort on. Members without the sorting property are always placed at the end of the group after the sort, in no particular order. Checking the index existence prevents the method from throwing an exception in case it encounters an object without the sorting property, but it causes a huge performance penalty. Default value is <code>true</code>. 
 		 */
-		public function sort(Index:String="y",Order:int=ASCENDING):void
+		public function sort(Index:String="y",Order:int=ASCENDING,CheckIndexExistence:Boolean=true):void
 		{
 			_sortIndex = Index;
 			_sortOrder = Order;
+			_sortCheckIndexExistence = CheckIndexExistence;
 			members.sort(sortHandler);
 		}
 
@@ -565,12 +574,14 @@ package org.flixel
 		 */
 		protected function sortHandler(Obj1:FlxBasic,Obj2:FlxBasic):int
 		{
-			// If the sorting property is missing, place the object at the end of the list.
-			if(!Obj1.hasOwnProperty(_sortIndex))
-				return 1;
-			else if(!Obj2.hasOwnProperty(_sortIndex))
-				return -1;
-			
+			if (_sortCheckIndexExistence == true)
+			{
+				// If the sorting property is missing, place the object at the end of the list.
+				if(!(_sortIndex in Obj1))
+					return 1;
+				else if(!(_sortIndex in Obj2))
+					return -1;
+			}
 			if(Obj1[_sortIndex] < Obj2[_sortIndex])
 				return _sortOrder;
 			else if(Obj1[_sortIndex] > Obj2[_sortIndex])


### PR DESCRIPTION
If an object does not have the sorting property, it is placed at the end of the list.

Fix:
https://github.com/FlixelCommunity/flixel/issues/28
https://github.com/AdamAtomic/flixel/issues/204
