### PR TITLE
Fix FlxG.removeCamera does not remove the camera from FlxG.cameras

### DIFF
--- a/org/flixel/FlxCamera.as
+++ b/org/flixel/FlxCamera.as
@@ -266,7 +266,8 @@ package org.flixel
 		 */
 		override public function destroy():void
 		{
-			screen.destroy();
+			if(screen != null)
+				screen.destroy();
 			screen = null;
 			target = null;
 			scroll = null;

--- a/org/flixel/FlxG.as
+++ b/org/flixel/FlxG.as
@@ -848,6 +848,7 @@ package org.flixel
 		{
 			try
 			{
+				FlxG.cameras.splice(FlxG.cameras.indexOf(Camera), 1);
 				FlxG._game.removeChild(Camera._flashSprite);
 			}
 			catch(E:Error)

--- a/org/flixel/FlxG.as
+++ b/org/flixel/FlxG.as
@@ -846,15 +846,14 @@ package org.flixel
 		 */
 		static public function removeCamera(Camera:FlxCamera,Destroy:Boolean=true):void
 		{
-			try
+			if(Camera && FlxG._game.contains(Camera._flashSprite))
 			{
 				FlxG.cameras.splice(FlxG.cameras.indexOf(Camera), 1);
 				FlxG._game.removeChild(Camera._flashSprite);
 			}
-			catch(E:Error)
-			{
+			else 
 				FlxG.log("Error removing camera, not part of game.");
-			}
+				
 			if(Destroy)
 				Camera.destroy();
 		}


### PR DESCRIPTION
I've tested it using this demo: https://github.com/phmongeau/SplitScreen

Fix:
https://github.com/FlixelCommunity/flixel/issues/1
https://github.com/AdamAtomic/flixel/issues/231
