### PR TITLE
Fix FlxText and problem with camera zoom

### DIFF
--- a/org/flixel/FlxCamera.as
+++ b/org/flixel/FlxCamera.as
@@ -318,15 +318,24 @@ package org.flixel
 			
 			//Make sure we didn't go outside the camera's bounds
 			if(bounds != null)
-			{
-				if(scroll.x < bounds.left)
-					scroll.x = bounds.left;
-				if(scroll.x > bounds.right - width)
-					scroll.x = bounds.right - width;
-				if(scroll.y < bounds.top)
-					scroll.y = bounds.top;
-				if(scroll.y > bounds.bottom - height)
-					scroll.y = bounds.bottom - height;
+			{	
+				var zoomOffsetWidth:Number = 0;
+				var zoomOffsetHeight:Number = 0;
+				
+				if (zoom > 1)
+				{
+					zoomOffsetWidth = width * (zoom - 1) / (2 * zoom);
+					zoomOffsetHeight = height * (zoom - 1) / (2 * zoom);
+				}
+				
+				if(scroll.x < bounds.left - zoomOffsetWidth)
+					scroll.x = bounds.left - zoomOffsetWidth;
+				if(scroll.x > bounds.right - width + zoomOffsetWidth)
+					scroll.x = bounds.right - width + zoomOffsetWidth;
+				if(scroll.y < bounds.top - zoomOffsetHeight)
+					scroll.y = bounds.top - zoomOffsetHeight;
+				if(scroll.y > bounds.bottom - height + zoomOffsetHeight)
+					scroll.y = bounds.bottom - height + zoomOffsetHeight;
 			}
 			
 			//Update the "flash" special effect


### PR DESCRIPTION
The problem was not related to FlxText only, but any FlxSprite. If the zoom was much greater than 1x (e.g 1.5x or 2x), objects positioned near the border of the screen would not be displayed.

It was happening because FlxCamera did not adjust its bounds when the zoom changes. As a consequence, if the camera had a zoom of 2x, the bounds would allow it to see just the elements within the 1x rectangle. The problem does not happen when the zoom is <= 1x.

I fixed the problem by adding a "zoom offset" to the bounds when checking them.

Fix:

https://github.com/FlixelCommunity/flixel/issues/50
https://github.com/AdamAtomic/flixel/issues/181
