### PR TITLE
Log error if invalid Bitmap passed to `FlxG.addBitmap()`

### DIFF
--- a/org/flixel/FlxG.as
+++ b/org/flixel/FlxG.as
@@ -745,7 +745,14 @@ package org.flixel
 			//If there is no data for this key, generate the requested graphic
 			if(!checkBitmapCache(Key))
 			{
-				var pixels:BitmapData = (new Graphic()).bitmapData;
+				var bitmap:Bitmap = new Graphic() as Bitmap;
+				if(bitmap == null)
+				{
+					FlxG.log("Error: " + FlxU.getClassName(Graphic) + " must extend flash.display.Bitmap.");
+					return FlxG.addBitmap(FlxSprite.ImgDefault, Reverse);
+				}
+				
+				var pixels:BitmapData = bitmap.bitmapData;
 				if(Reverse)
 				{
 					var newPixels:BitmapData = new BitmapData(pixels.width<<1,pixels.height,true,0x00000000);


### PR DESCRIPTION
Resolves the following issue:
- FlxG.as line 738,743 undefined property bitmapData (https://github.com/FlixelCommunity/flixel/issues/15, https://github.com/AdamAtomic/flixel/issues/217)
