### PR TITLE
Fix `FlxCamera` "jitters" when following a target

### DIFF
--- a/org/flixel/FlxCamera.as
+++ b/org/flixel/FlxCamera.as
@@ -302,7 +302,7 @@ package org.flixel
 					var targetX:Number = target.x + ((target.x > 0)?0.0000001:-0.0000001);
 					var targetY:Number = target.y + ((target.y > 0)?0.0000001:-0.0000001);
 					
-					if ((target is FlxSprite) && (FlxSprite(target).isSimpleRender))
+					if ((target is FlxSprite) && (FlxSprite(target).isSimpleRender()))
 					{
 						targetX = FlxU.ceil(targetX);
 						targetY = FlxU.ceil(targetY);
@@ -406,7 +406,8 @@ package org.flixel
 					deadzone = new FlxRect((width-helper)/2,(height-helper)/2,helper,helper);
 					break;
 				case STYLE_LOCKON:
-					if (target != null) {	
+					if (target != null) 
+					{	
 						w = target.width;
 						h = target.height;
 					}

--- a/org/flixel/FlxCamera.as
+++ b/org/flixel/FlxCamera.as
@@ -302,6 +302,12 @@ package org.flixel
 					var targetX:Number = target.x + ((target.x > 0)?0.0000001:-0.0000001);
 					var targetY:Number = target.y + ((target.y > 0)?0.0000001:-0.0000001);
 					
+					if (FlxSprite(target).simpleRender)
+					{
+						targetX = FlxU.ceil(targetX);
+						targetY = FlxU.ceil(targetY);
+					}
+					
 					edge = targetX - deadzone.x;
 					if(scroll.x > edge)
 						scroll.x = edge;
@@ -381,11 +387,14 @@ package org.flixel
 		{
 			target = Target;
 			var helper:Number;
+			var w:Number = 0;
+			var h:Number = 0;
+			
 			switch(Style)
 			{
 				case STYLE_PLATFORMER:
-					var w:Number = width/8;
-					var h:Number = height/3;
+					w = width/8;
+					h = height/3;
 					deadzone = new FlxRect((width-w)/2,(height-h)/2 - h*0.25,w,h);
 					break;
 				case STYLE_TOPDOWN:
@@ -397,6 +406,12 @@ package org.flixel
 					deadzone = new FlxRect((width-helper)/2,(height-helper)/2,helper,helper);
 					break;
 				case STYLE_LOCKON:
+					if (target != null) {	
+						w = target.width;
+						h = target.height;
+					}
+					deadzone = new FlxRect((width-w)/2,(height-h)/2 - h * 0.25,w,h);
+					break;
 				default:
 					deadzone = null;
 					break;

--- a/org/flixel/FlxCamera.as
+++ b/org/flixel/FlxCamera.as
@@ -302,7 +302,7 @@ package org.flixel
 					var targetX:Number = target.x + ((target.x > 0)?0.0000001:-0.0000001);
 					var targetY:Number = target.y + ((target.y > 0)?0.0000001:-0.0000001);
 					
-					if (FlxSprite(target).simpleRender)
+					if ((target is FlxSprite) && (FlxSprite(target).isSimpleRender))
 					{
 						targetX = FlxU.ceil(targetX);
 						targetY = FlxU.ceil(targetY);

--- a/org/flixel/FlxSprite.as
+++ b/org/flixel/FlxSprite.as
@@ -158,7 +158,7 @@ package org.flixel
 		/**
 		 * If the Sprite is beeing rendered in simple mode.
 		 */
-		public function get simpleRender():Boolean { 
+		public function get isSimpleRender():Boolean { 
 			return ((angle == 0) || (_bakedRotation > 0)) && (scale.x == 1) && (scale.y == 1) && (blend == null)
 		}
 		
@@ -453,7 +453,7 @@ package org.flixel
 				_point.y = y - int(camera.scroll.y*scrollFactor.y) - FlxU.floor(offset.y);
 				_point.x += (_point.x > 0)?0.0000001:-0.0000001;
 				_point.y += (_point.y > 0)?0.0000001:-0.0000001;
-				if(simpleRender)
+				if(isSimpleRender)
 				{	//Simple render
 					_flashPoint.x = _point.x;
 					_flashPoint.y = _point.y;

--- a/org/flixel/FlxSprite.as
+++ b/org/flixel/FlxSprite.as
@@ -156,6 +156,13 @@ package org.flixel
 		protected var _matrix:Matrix;
 		
 		/**
+		 * If the Sprite is beeing rendered in simple mode.
+		 */
+		public function get simpleRender():Boolean { 
+			return ((angle == 0) || (_bakedRotation > 0)) && (scale.x == 1) && (scale.y == 1) && (blend == null)
+		}
+		
+		/**
 		 * Creates a white 8x8 square <code>FlxSprite</code> at the specified position.
 		 * Optionally can load a simple, one-frame graphic instead.
 		 * 
@@ -442,11 +449,11 @@ package org.flixel
 				camera = cameras[i++];
 				if(!onScreen(camera))
 					continue;
-				_point.x = x - int(camera.scroll.x*scrollFactor.x) - offset.x;
-				_point.y = y - int(camera.scroll.y*scrollFactor.y) - offset.y;
+				_point.x = x - int(camera.scroll.x*scrollFactor.x) - FlxU.floor(offset.x);
+				_point.y = y - int(camera.scroll.y*scrollFactor.y) - FlxU.floor(offset.y);
 				_point.x += (_point.x > 0)?0.0000001:-0.0000001;
 				_point.y += (_point.y > 0)?0.0000001:-0.0000001;
-				if(((angle == 0) || (_bakedRotation > 0)) && (scale.x == 1) && (scale.y == 1) && (blend == null))
+				if(simpleRender)
 				{	//Simple render
 					_flashPoint.x = _point.x;
 					_flashPoint.y = _point.y;

--- a/org/flixel/FlxSprite.as
+++ b/org/flixel/FlxSprite.as
@@ -158,7 +158,8 @@ package org.flixel
 		/**
 		 * If the Sprite is beeing rendered in simple mode.
 		 */
-		public function get isSimpleRender():Boolean { 
+		public function isSimpleRender():Boolean 
+		{
 			return ((angle == 0) || (_bakedRotation > 0)) && (scale.x == 1) && (scale.y == 1) && (blend == null)
 		}
 		
@@ -453,14 +454,15 @@ package org.flixel
 				_point.y = y - int(camera.scroll.y*scrollFactor.y) - FlxU.floor(offset.y);
 				_point.x += (_point.x > 0)?0.0000001:-0.0000001;
 				_point.y += (_point.y > 0)?0.0000001:-0.0000001;
-				if(isSimpleRender)
-				{	//Simple render
+				
+				if(isSimpleRender())
+				{
 					_flashPoint.x = _point.x;
 					_flashPoint.y = _point.y;
 					camera.buffer.copyPixels(framePixels,_flashRect,_flashPoint,null,null,true);
 				}
-				else
-				{	//Advanced render
+				else //Advanced render
+				{
 					_matrix.identity();
 					_matrix.translate(-origin.x,-origin.y);
 					_matrix.scale(scale.x,scale.y);
@@ -469,6 +471,7 @@ package org.flixel
 					_matrix.translate(_point.x+origin.x,_point.y+origin.y);
 					camera.buffer.draw(framePixels,_matrix,null,blend,null,antialiasing);
 				}
+				
 				_VISIBLECOUNT++;
 				if(FlxG.visualDebug && !ignoreDrawDebug)
 					drawDebug(camera);


### PR DESCRIPTION
Resolves the following issue:
- FlxCamera follow jitters (https://github.com/FlixelCommunity/flixel/issues/5, https://github.com/AdamAtomic/flixel/issues/227)

Fix provided by [Krix](https://github.com/krix)
