### PR TITLE
No need to fill a camera twice if not blending alpha

### DIFF
--- a/org/flixel/FlxCamera.as
+++ b/org/flixel/FlxCamera.as
@@ -671,8 +671,16 @@ package org.flixel
 		 */
 		public function fill(Color:uint,BlendAlpha:Boolean=true):void
 		{
-			_fill.fillRect(_flashRect,Color);
-			buffer.copyPixels(_fill,_flashRect,_flashPoint,null,null,BlendAlpha);
+			var alpha:uint = Color >>> 24;
+			if(alpha == 255 || !BlendAlpha)
+			{
+				buffer.fillRect(_flashRect,Color);
+			}
+			else
+			{
+				_fill.fillRect(_flashRect,Color);
+				buffer.copyPixels(_fill,_flashRect,_flashPoint,null,null,BlendAlpha);
+			}
 		}
 		
 		/**


### PR DESCRIPTION
Fixed https://github.com/FlixelCommunity/flixel/issues/106
