### PR TITLE
Fix compile issues and change FlxSprite.ImgDefault to be public static

### DIFF
--- a/org/flixel/FlxG.as
+++ b/org/flixel/FlxG.as
@@ -1,6 +1,7 @@
 package org.flixel
 {
 	import flash.display.BitmapData;
+  import flash.display.Bitmap;
 	import flash.display.Graphics;
 	import flash.display.Sprite;
 	import flash.display.Stage;

--- a/org/flixel/FlxSprite.as
+++ b/org/flixel/FlxSprite.as
@@ -18,7 +18,7 @@ package org.flixel
 	 */
 	public class FlxSprite extends FlxObject
 	{
-		[Embed(source="data/default.png")] protected var ImgDefault:Class;
+		[Embed(source="data/default.png")] public static var ImgDefault:Class;
 		
 		/**
 		 * WARNING: The origin of the sprite will default to its center.


### PR DESCRIPTION
This fixes issue #150 and another unrelated compile issue due to a missing import.
