### PR TITLE
Prevent errors if `destroy()` is called twice

### DIFF
--- a/org/flixel/FlxTilemap.as
+++ b/org/flixel/FlxTilemap.as
@@ -157,16 +157,25 @@ package org.flixel
 			_flashPoint = null;
 			_flashRect = null;
 			_tiles = null;
-			var i:uint = 0;
-			var l:uint = _tileObjects.length;
-			while(i < l)
-				(_tileObjects[i++] as FlxTile).destroy();
-			_tileObjects = null;
-			i = 0;
-			l = _buffers.length;
-			while(i < l)
-				(_buffers[i++] as FlxTilemapBuffer).destroy();
-			_buffers = null;
+			
+			if (_tileObjects != null)
+			{
+				var i:uint = 0;
+				var l:uint = _tileObjects.length;
+				while(i < l)
+					(_tileObjects[i++] as FlxTile).destroy();
+				_tileObjects = null;
+			}
+			
+			if (_buffers != null)
+			{
+				i = 0;
+				l = _buffers.length;
+				while(i < l)
+					(_buffers[i++] as FlxTilemapBuffer).destroy();
+				_buffers = null;
+			}
+			
 			_data = null;
 			_rects = null;
 			_debugTileNotSolid = null;

--- a/org/flixel/plugin/DebugPathDisplay.as
+++ b/org/flixel/plugin/DebugPathDisplay.as
@@ -98,15 +98,17 @@ package org.flixel.plugin
 		 */
 		public function clear():void
 		{
-			var i:int = _paths.length-1;
-			var path:FlxPath;
-			while(i >= 0)
+			if (_paths != null)
 			{
-				path = _paths[i--] as FlxPath;
-				if(path != null)
-					path.destroy();
+				var i:int = _paths.length-1;
+				while(i >= 0)
+				{
+					var path:FlxPath = _paths[i--] as FlxPath;
+					if(path != null)
+						path.destroy();
+				}
+				_paths.length = 0;
 			}
-			_paths.length = 0;
 		}
 	}
 }

--- a/org/flixel/plugin/TimerManager.as
+++ b/org/flixel/plugin/TimerManager.as
@@ -75,15 +75,17 @@ package org.flixel.plugin
 		 */
 		public function clear():void
 		{
-			var i:int = _timers.length-1;
-			var timer:FlxTimer;
-			while(i >= 0)
+			if (_timers != null)
 			{
-				timer = _timers[i--] as FlxTimer;
-				if(timer != null)
-					timer.destroy();
+				var i:int = _timers.length-1;
+				while(i >= 0)
+				{
+					var timer:FlxTimer = _timers[i--] as FlxTimer;
+					if(timer != null)
+						timer.destroy();
+				}
+				_timers.length = 0;
 			}
-			_timers.length = 0;
 		}
 	}
 }

--- a/org/flixel/system/FlxDebugger.as
+++ b/org/flixel/system/FlxDebugger.as
@@ -126,21 +126,41 @@ package org.flixel.system
 		public function destroy():void
 		{
 			_screen = null;
-			removeChild(log);
-			log.destroy();
-			log = null;
-			removeChild(watch);
-			watch.destroy();
-			watch = null;
-			removeChild(perf);
-			perf.destroy();
-			perf = null;
-			removeChild(vcr);
-			vcr.destroy();
-			vcr = null;
-			removeChild(vis);
-			vis.destroy();
-			vis = null;
+			
+			if (log != null)
+			{
+				removeChild(log);
+				log.destroy();
+				log = null;
+			}
+			
+			if (watch != null)
+			{
+				removeChild(watch);
+				watch.destroy();
+				watch = null;
+			}
+			
+			if (perf != null)
+			{
+				removeChild(perf);
+				perf.destroy();
+				perf = null;
+			}
+			
+			if (vcr != null)
+			{
+				removeChild(vcr);
+				vcr.destroy();
+				vcr = null;
+			}
+			
+			if (vis != null)
+			{
+				removeChild(vis);
+				vis.destroy();
+				vis = null;
+			}
 			
 			removeEventListener(MouseEvent.MOUSE_OVER,handleMouseOver);
 			removeEventListener(MouseEvent.MOUSE_OUT,handleMouseOut);

--- a/org/flixel/system/FlxPreloader.as
+++ b/org/flixel/system/FlxPreloader.as
@@ -237,7 +237,8 @@ package org.flixel.system
 		
 		protected function destroy():void
 		{
-			removeChild(_buffer);
+			if (_buffer != null)
+				removeChild(_buffer);
 			_buffer = null;
 			_bmpBar = null;
 			_text = null;

--- a/org/flixel/system/FlxQuadTree.as
+++ b/org/flixel/system/FlxQuadTree.as
@@ -258,13 +258,17 @@ package org.flixel.system
 		 */
 		public function destroy():void
 		{
-			_headA.destroy();
+			if(_headA != null)
+				_headA.destroy();
 			_headA = null;
-			_tailA.destroy();
+			if(_tailA != null)
+				_tailA.destroy();
 			_tailA = null;
-			_headB.destroy();
+			if(_headB != null)
+				_headB.destroy();
 			_headB = null;
-			_tailB.destroy();
+			if(_tailB != null)
+				_tailB.destroy();
 			_tailB = null;
 
 			if(_northWestTree != null)

--- a/org/flixel/system/FlxReplay.as
+++ b/org/flixel/system/FlxReplay.as
@@ -64,12 +64,13 @@ package org.flixel.system
 		 */
 		public function destroy():void
 		{
-			if(_frames == null)
-				return;
-			var i:int = frameCount-1;
-			while(i >= 0)
-				(_frames[i--] as FrameRecord).destroy();
-			_frames = null;
+			if(_frames != null)
+			{
+				var i:int = frameCount-1;
+				while(i >= 0)
+					(_frames[i--] as FrameRecord).destroy();
+				_frames = null;
+			}
 		}
 		
 		/**

--- a/org/flixel/system/FlxWindow.as
+++ b/org/flixel/system/FlxWindow.as
@@ -152,13 +152,17 @@ package org.flixel.system
 			minSize = null;
 			maxSize = null;
 			_bounds = null;
-			removeChild(_shadow);
+			if (_shadow != null)
+				removeChild(_shadow);
 			_shadow = null;
-			removeChild(_background);
+			if (_background != null)
+				removeChild(_background);
 			_background = null;
-			removeChild(_header);
+			if (_header != null)
+				removeChild(_header);
 			_header = null;
-			removeChild(_title);
+			if (_title != null)
+				removeChild(_title);
 			_title = null;
 			if(_handle != null)
 				removeChild(_handle);

--- a/org/flixel/system/debug/Log.as
+++ b/org/flixel/system/debug/Log.as
@@ -49,7 +49,7 @@ package org.flixel.system.debug
 		 */
 		override public function destroy():void
 		{
-			removeChild(_text);
+			if (_text) removeChild(_text);
 			_text = null;
 			_lines = null;
 			super.destroy();

--- a/org/flixel/system/debug/Perf.as
+++ b/org/flixel/system/debug/Perf.as
@@ -78,7 +78,7 @@ package org.flixel.system.debug
 		 */
 		override public function destroy():void
 		{
-			removeChild(_text);
+			if (_text) removeChild(_text);
 			_text = null;
 			_flixelUpdate = null;
 			_flixelDraw = null;

--- a/org/flixel/system/debug/VCR.as
+++ b/org/flixel/system/debug/VCR.as
@@ -150,23 +150,23 @@ package org.flixel.system.debug
 		{
 			_file = null;
 			
-			removeChild(_open);
+			if (_open) removeChild(_open);
 			_open = null;
-			removeChild(_recordOff);
+			if (_recordOff) removeChild(_recordOff);
 			_recordOff = null;
-			removeChild(_recordOn);
+			if (_recordOn) removeChild(_recordOn);
 			_recordOn = null;
-			removeChild(_stop);
+			if (_stop) removeChild(_stop);
 			_stop = null;
-			removeChild(_flixel);
+			if (_flixel) removeChild(_flixel);
 			_flixel = null;
-			removeChild(_restart);
+			if (_restart) removeChild(_restart);
 			_restart = null;
-			removeChild(_pause);
+			if (_pause) removeChild(_pause);
 			_pause = null;
-			removeChild(_play);
+			if (_play) removeChild(_play);
 			_play = null;
-			removeChild(_step);
+			if (_step) removeChild(_step);
 			_step = null;
 			
 			parent.removeEventListener(MouseEvent.MOUSE_MOVE,handleMouseMove);

--- a/org/flixel/system/debug/VCR.as
+++ b/org/flixel/system/debug/VCR.as
@@ -169,9 +169,12 @@ package org.flixel.system.debug
 			if (_step) removeChild(_step);
 			_step = null;
 			
-			parent.removeEventListener(MouseEvent.MOUSE_MOVE,handleMouseMove);
-			parent.removeEventListener(MouseEvent.MOUSE_DOWN,handleMouseDown);
-			parent.removeEventListener(MouseEvent.MOUSE_UP,handleMouseUp);
+			if (parent)
+			{
+				parent.removeEventListener(MouseEvent.MOUSE_MOVE,handleMouseMove);
+				parent.removeEventListener(MouseEvent.MOUSE_DOWN,handleMouseDown);
+				parent.removeEventListener(MouseEvent.MOUSE_UP,handleMouseUp);
+			}
 		}
 		
 		/**

--- a/org/flixel/system/debug/Vis.as
+++ b/org/flixel/system/debug/Vis.as
@@ -49,9 +49,12 @@ package org.flixel.system.debug
 			if (_bounds) removeChild(_bounds);
 			_bounds = null;
 			
-			parent.removeEventListener(MouseEvent.MOUSE_MOVE,handleMouseMove);
-			parent.removeEventListener(MouseEvent.MOUSE_DOWN,handleMouseDown);
-			parent.removeEventListener(MouseEvent.MOUSE_UP,handleMouseUp);
+			if (parent)
+			{
+				parent.removeEventListener(MouseEvent.MOUSE_MOVE,handleMouseMove);
+				parent.removeEventListener(MouseEvent.MOUSE_DOWN,handleMouseDown);
+				parent.removeEventListener(MouseEvent.MOUSE_UP,handleMouseUp);
+			}
 		}
 		
 		//***ACTUAL BUTTON BEHAVIORS***//

--- a/org/flixel/system/debug/Vis.as
+++ b/org/flixel/system/debug/Vis.as
@@ -46,7 +46,7 @@ package org.flixel.system.debug
 		 */
 		public function destroy():void
 		{
-			removeChild(_bounds);
+			if (_bounds) removeChild(_bounds);
 			_bounds = null;
 			
 			parent.removeEventListener(MouseEvent.MOUSE_MOVE,handleMouseMove);

--- a/org/flixel/system/debug/Watch.as
+++ b/org/flixel/system/debug/Watch.as
@@ -65,15 +65,20 @@ package org.flixel.system.debug
 		 */
 		override public function destroy():void
 		{
-			removeChild(_names);
+			if (_names) removeChild(_names);
 			_names = null;
-			removeChild(_values);
+			if (_values) removeChild(_values);
 			_values = null;
-			var i:int = 0;
-			var l:uint = _watching.length;
-			while(i < l)
-				(_watching[i++] as WatchEntry).destroy();
-			_watching = null;
+			
+			if (_watching != null)
+			{
+				var i:int = 0;
+				var l:uint = _watching.length;
+				while(i < l)
+					(_watching[i++] as WatchEntry).destroy();
+				_watching = null;
+			}
+			
 			super.destroy();
 		}
 

--- a/org/flixel/system/debug/WatchEntry.as
+++ b/org/flixel/system/debug/WatchEntry.as
@@ -100,9 +100,13 @@ package org.flixel.system.debug
 			nameDisplay = null;
 			field = null;
 			custom = null;
-			valueDisplay.removeEventListener(MouseEvent.MOUSE_UP,handleMouseUp);
-			valueDisplay.removeEventListener(KeyboardEvent.KEY_UP,handleKeyUp);
-			valueDisplay = null;
+			
+			if (valueDisplay != null)
+			{
+				valueDisplay.removeEventListener(MouseEvent.MOUSE_UP,handleMouseUp);
+				valueDisplay.removeEventListener(KeyboardEvent.KEY_UP,handleKeyUp);
+				valueDisplay = null;
+			}
 		}
 		
 		/**


### PR DESCRIPTION
Add checks before accessing object properties to see if they hadn't already been set to `null`.

Not modified the package `org.flixel.system.debug.*`

A few classes are destroyed automatically by Flixel (which guarantees they are only destroyed once), but some foolish user (or derailed bug) may decide to destroy something anyway, and since `if` checks are so cheap, it's better to be safe than sorry.
