### PR TITLE
Prevent setting a FlxSprite to an invalid frame

### DIFF
--- a/org/flixel/FlxEmitter.as
+++ b/org/flixel/FlxEmitter.as
@@ -168,7 +168,7 @@ package org.flixel
 			{ 
 				var sprite:FlxSprite = new FlxSprite();
 				sprite.loadGraphic(Graphics,true);
-				totalFrames = sprite.frames;
+				totalFrames = sprite.numFrames;
 				sprite.destroy();
 			}
 

--- a/org/flixel/FlxSprite.as
+++ b/org/flixel/FlxSprite.as
@@ -65,10 +65,6 @@ package org.flixel
 		 */
 		public var frameHeight:uint;
 		/**
-		 * The total number of frames in this image.  WARNING: assumes each row in the sprite sheet is full!
-		 */
-		public var frames:uint;
-		/**
 		 * The actual Flash <code>BitmapData</code> object representing the current display state of the sprite.
 		 */
 		public var framePixels:BitmapData;
@@ -407,7 +403,6 @@ package org.flixel
 				framePixels = new BitmapData(width,height);
 			origin.make(frameWidth*0.5,frameHeight*0.5);
 			framePixels.copyPixels(_pixels,_flashRect,_flashPointZero);
-			frames = (_flashRect2.width / _flashRect.width) * (_flashRect2.height / _flashRect.height);
 			if(_colorTransform != null) framePixels.colorTransform(_flashRect,_colorTransform);
 			_curIndex = 0;
 			_numFrames = 0;

--- a/org/flixel/FlxSprite.as
+++ b/org/flixel/FlxSprite.as
@@ -880,7 +880,17 @@ package org.flixel
 		}
 		
 		/**
-		 * The number of frames are on the sprite sheet. Defaults to <code>maxFrames</code> if no value is set.
+		 * The number of frames that are on the sprite sheet.
+		 * 
+		 * @deprecated This property is deprecated. Use <code>numFrames</code> instead.
+		 */
+		public function get frames():uint
+		{
+			return numFrames;
+		}
+		
+		/**
+		 * The number of frames that are on the sprite sheet. Defaults to <code>maxFrames</code> if no value is set.
 		 * 
 		 * @param	NumFrames	The number of frames on the sprite sheet. Has to be a value between <code>1</code> and <code>maxFrames</code>.
 		 */

--- a/org/flixel/FlxSprite.as
+++ b/org/flixel/FlxSprite.as
@@ -886,7 +886,7 @@ package org.flixel
 		 */
 		public function get numFrames():uint
 		{
-			return (_numFrames == -1) ? maxFrames : _numFrames;
+			return (_numFrames == 0) ? maxFrames : _numFrames;
 		}
 		
 		/**

--- a/org/flixel/FlxSprite.as
+++ b/org/flixel/FlxSprite.as
@@ -96,6 +96,11 @@ package org.flixel
 		 */
 		protected var _curIndex:uint;
 		/**
+		 * Internal, tracker for the maximum number of frames that can fit on the tile sheet, used with read-only getter.
+		 * WARNING: assumes each row in the sprite sheet is full!
+		 */
+		protected var _maxFrames:uint;
+		/**
 		 * Internal, tracker for the number of frames on the tile sheet, used with Flash getter/setter.
 		 */
 		protected var _numFrames:uint;
@@ -189,6 +194,7 @@ package org.flixel
 			_curFrame = 0;
 			_curIndex = 0;
 			_numFrames = 0;
+			_maxFrames = 0;
 			_frameTimer = 0;
 
 			_matrix = new Matrix();
@@ -406,6 +412,11 @@ package org.flixel
 			if(_colorTransform != null) framePixels.colorTransform(_flashRect,_colorTransform);
 			_curIndex = 0;
 			_numFrames = 0;
+			
+			var widthHelper:uint = _flipped?_flipped:_pixels.width;
+			var maxFramesX:uint = FlxU.ceil(widthHelper / frameWidth);
+			var maxFramesY:uint = FlxU.ceil(_pixels.height / frameHeight);
+			_maxFrames = maxFramesX * maxFramesY;
 		}
 		
 		/**
@@ -865,10 +876,7 @@ package org.flixel
 		 */
 		public function get maxFrames():uint
 		{
-			var widthHelper:uint = _flipped?_flipped:_pixels.width;
-			var maxFramesX:uint = FlxU.ceil(widthHelper / frameWidth);
-			var maxFramesY:uint = FlxU.ceil(_pixels.height / frameHeight);
-			return maxFramesX * maxFramesY;
+			return _maxFrames;
 		}
 		
 		/**

--- a/org/flixel/FlxTileblock.as
+++ b/org/flixel/FlxTileblock.as
@@ -45,7 +45,7 @@ package org.flixel
 			var sprite:FlxSprite = new FlxSprite().loadGraphic(TileGraphic,true,false,TileWidth,TileHeight);
 			var spriteWidth:uint = sprite.width;
 			var spriteHeight:uint = sprite.height;
-			var total:uint = sprite.frames + Empties;
+			var total:uint = sprite.numFrames + Empties;
 			
 			//Then prep the "canvas" as it were (just doublechecking that the size is on tile boundaries)
 			var regen:Boolean = false;


### PR DESCRIPTION
Fixes https://github.com/FlixelCommunity/flixel/issues/13

Prevents an "out of range" frame number from being set either by an
animation, or by manually setting the `frame` property.

Adds new getter/setter `numFrames` where user can manually specify how
many frames an animation has (in case some frame are empty).

To go hand in hand with this is the read-only property `maxFrames` which
calculates how many frames can fit on that sprite sheet. NOTE: it rounds
up, so sprites may "hang off the edge" if the sheet is the wrong
dimensions. This may be fixed in the future depending on how other
applications handle "overhanging frames".
