### PR TITLE
Fix regression with FlxText regarding the "moves" property.

### DIFF
--- a/src/org/flixel/FlxObject.as
+++ b/src/org/flixel/FlxObject.as
@@ -193,7 +193,7 @@ package org.flixel
 		/**
 		 * Set this to false if you want to skip the automatic motion/movement stuff (see <code>updateMotion()</code>).
 		 * FlxObject and FlxSprite default to true.
-		 * FlxText, FlxTileblock, and FlxTilemap default to false.
+		 * FlxTileblock and FlxTilemap default to false.
 		 */
 		public var moves:Boolean;
 		/**

--- a/src/org/flixel/FlxObject.as
+++ b/src/org/flixel/FlxObject.as
@@ -192,7 +192,7 @@ package org.flixel
 		protected var _rect:FlxRect;
 		/**
 		 * Set this to false if you want to skip the automatic motion/movement stuff (see <code>updateMotion()</code>).
-		 * FlxObject and FlxSprite default to true.
+		 * FlxObject, FlxSprite and FlxText default to true.
 		 * FlxTileblock and FlxTilemap default to false.
 		 */
 		public var moves:Boolean;

--- a/src/org/flixel/FlxText.as
+++ b/src/org/flixel/FlxText.as
@@ -64,7 +64,6 @@ package org.flixel
 			_regen = true;
 			_shadow = 0;
 			allowCollisions = NONE;
-			moves = false;
 			calcFrame();
 		}
 		


### PR DESCRIPTION
By default any FlxText was able to move, but some change we did changed that. We explicitly set "moves" to false, which made all FlxText to stop moving unless otherwise specified.

I removed the "moves = false" from FlxText's contructor and everything is working as before.
