### PR TITLE
Fix a regression with FlxSprite's _maxFrames calculation.

### DIFF
--- a/src/org/flixel/FlxSprite.as
+++ b/src/org/flixel/FlxSprite.as
@@ -421,8 +421,8 @@ package org.flixel
 			_numFrames = 0;
 			
 			var widthHelper:uint = _flipped?_flipped:_pixels.width;
-			var maxFramesX:uint = widthHelper / frameWidth;
-			var maxFramesY:uint = _pixels.height / frameHeight;
+			var maxFramesX:uint = FlxU.floor(widthHelper / frameWidth);
+			var maxFramesY:uint = FlxU.floor(_pixels.height / frameHeight);
 			_maxFrames = maxFramesX * maxFramesY;
 		}
 		

--- a/src/org/flixel/FlxSprite.as
+++ b/src/org/flixel/FlxSprite.as
@@ -421,8 +421,8 @@ package org.flixel
 			_numFrames = 0;
 			
 			var widthHelper:uint = _flipped?_flipped:_pixels.width;
-			var maxFramesX:uint = FlxU.ceil(widthHelper / frameWidth);
-			var maxFramesY:uint = FlxU.ceil(_pixels.height / frameHeight);
+			var maxFramesX:uint = widthHelper / frameWidth;
+			var maxFramesY:uint = _pixels.height / frameHeight;
 			_maxFrames = maxFramesX * maxFramesY;
 		}
 		


### PR DESCRIPTION
The current approach assumed perfectly filled spritesheets rows. It used ceil() to adjust any floating value, which resulted in a blank column at the right of some graphics.

I've noticed that testing with a game that uses particles. Some particles had that blank column. Removing the ceil (which was Adam's original approach) fixed the problem.
