### PR TITLE
Fix `FlxGroup#maxSize`

### DIFF
--- a/src/org/flixel/FlxGroup.as
+++ b/src/org/flixel/FlxGroup.as
@@ -147,18 +147,14 @@ package org.flixel
 				_marker = 0;
 			if((_maxSize == 0) || (members == null) || (_maxSize >= members.length))
 				return;
-			
+	
 			//If the max size has shrunk, we need to get rid of some objects
-			var basic:FlxBasic;
-			var i:uint = _maxSize;
-			var l:uint = members.length;
-			while(i < l)
+			while(members.length > _maxSize)
 			{
-				basic = members[i++] as FlxBasic;
-				if(basic != null)
-					basic.destroy();
+				var basic:FlxBasic = members.pop() as FlxBasic;
+				if(basic != null) basic.destroy();
 			}
-			length = members.length = _maxSize;
+			length = members.length;
 		}
 		
 		/**


### PR DESCRIPTION
In the old behavior, if you set the `maxSize` property of a `FlxGroup`, first it destroys all objects in the group that it was not planning on removing, then just drops the rest from the list of members (without even destroying them first) by setting `members.length`.

``` as3
public function set maxSize(Size:uint):void
{
    _maxSize = Size;
    if(_marker >= _maxSize)
        _marker = 0;
    if((_maxSize == 0) || (members == null) || (_maxSize >= members.length))
        return;

    //If the max size has shrunk, we need to get rid of some objects
    var basic:FlxBasic;
    var i:uint = _maxSize;
    var l:uint = members.length;
    while(i < l)
    {
        basic = members[i++] as FlxBasic;
        if(basic != null)
            basic.destroy();
    }
    length = members.length = _maxSize;
}
```

This fix makes sure to only remove the last elements, and only destroys the ones that it removes.
