### PR TITLE
Add `FlxGroup#killAll()` and `FlxGroup#reviveAll()`

### DIFF
--- a/src/org/flixel/FlxBasic.as
+++ b/src/org/flixel/FlxBasic.as
@@ -126,6 +126,9 @@ package org.flixel
 		 * However, if you want the "corpse" to remain in the game,
 		 * like to animate an effect or whatever, you should override this,
 		 * setting only alive to false, and leaving exists true.
+		 *
+		 * When used in a <code>FlxGroup</code>, the method will kill the group, but leave
+		 * the members alive; use <code>FlxGroup.killAll()</code> to kill any members.
 		 */
 		public function kill():void
 		{
@@ -136,6 +139,9 @@ package org.flixel
 		/**
 		 * Handy function for bringing game objects "back to life". Just sets alive and exists back to true.
 		 * In practice, this function is most often called by <code>FlxObject.reset()</code>.
+		 *
+		 * When used in a <code>FlxGroup</code>, the method will revive the group, but leave
+		 * the members as they were; use <code>FlxGroup.reviveAll()</code> to revive any members.
 		 */
 		public function revive():void
 		{

--- a/src/org/flixel/FlxGroup.as
+++ b/src/org/flixel/FlxGroup.as
@@ -555,36 +555,28 @@ package org.flixel
 		}
 		
 		/**
-		 * Calls kill on the group's members and then on the group itself.
+		 * Calls <code>kill()<code> on all of the group's members (but not on the group itself).
 		 */
-		override public function kill():void
+		override public function killAll():void
 		{
-			var basic:FlxBasic;
 			var i:uint = 0;
 			while(i < length)
 			{
-				basic = members[i++] as FlxBasic;
+				var basic:FlxBasic = members[i++] as FlxBasic;
 				if((basic != null) && basic.exists)
 					basic.kill();
 			}
-			
-			// Kill the group itself
-			super.kill();
 		}
 		
 		/**
-		 * Calls revive on the group itself and then on the group's members.
+		 * Calls <code>revive<code> on all of the group's members (but not on the group itself).
 		 */
-		override public function revive():void
+		public function reviveAll():void
 		{
-			// Revive the group itself
-			super.revive();
-			
-			var basic:FlxBasic;
 			var i:uint = 0;
 			while(i < length)
 			{
-				basic = members[i++] as FlxBasic;
+				var basic:FlxBasic = members[i++] as FlxBasic;
 				if((basic != null) && !basic.alive)
 					basic.revive();
 			}


### PR DESCRIPTION
See https://github.com/FlixelCommunity/flixel/issues/30#issuecomment-26753623

I also added a second commit which points out this new behavior of `FlxGroup#kill()` and just emphasizes the original behavior of `FlxGroup#revive()`. Since we are no longer overriding those methods, adding the relevant ASDoc inside `FlxGroup` would be possible, but seems more complicated than we need to make it. It's easier just to add the information to `FlxBasic` instead.

Should I keep the second commit, or remove it?
