### PR TITLE
Revert "Add `FlxGroup::revive()`"

### DIFF
--- a/src/org/flixel/FlxGroup.as
+++ b/src/org/flixel/FlxGroup.as
@@ -573,21 +573,12 @@ package org.flixel
 		}
 		
 		/**
-		 * Calls revive on the group itself and then on the group's members.
+		 * Calls revive on the group object. <i>Note: Does not revive any of the members!</i>
 		 */
 		override public function revive():void
 		{
 			// Revive the group itself
 			super.revive();
-			
-			var basic:FlxBasic;
-			var i:uint = 0;
-			while(i < length)
-			{
-				basic = members[i++] as FlxBasic;
-				if((basic != null) && !basic.alive)
-					basic.revive();
-			}
 		}
 		
 		/**


### PR DESCRIPTION
The following commit has been undone:
https://github.com/FlixelCommunity/flixel/pull/110

And a tiny bit of documentation has been added describing the changes.

Discussion:
- https://github.com/FlixelCommunity/flixel/pull/185
- https://github.com/FlixelCommunity/flixel/issues/30#issuecomment-26753623

The SWC compiles without any errors, but I have not tested the changes in a project.
