### PR TITLE
Fix offset by one in STYLE_LOCKON camera mode.

### DIFF
--- a/src/org/flixel/FlxCamera.as
+++ b/src/org/flixel/FlxCamera.as
@@ -304,8 +304,8 @@ package org.flixel
 					
 					if ((target is FlxSprite) && (FlxSprite(target).isSimpleRender()))
 					{
-						targetX = FlxU.ceil(targetX);
-						targetY = FlxU.ceil(targetY);
+						targetX = FlxU.floor(targetX);
+						targetY = FlxU.floor(targetY);
 					}
 					
 					edge = targetX - deadzone.x;

--- a/src/org/flixel/FlxSprite.as
+++ b/src/org/flixel/FlxSprite.as
@@ -461,8 +461,8 @@ package org.flixel
 				camera = cameras[i++];
 				if(!onScreen(camera))
 					continue;
-				_point.x = x - int(camera.scroll.x*scrollFactor.x) - FlxU.floor(offset.x);
-				_point.y = y - int(camera.scroll.y*scrollFactor.y) - FlxU.floor(offset.y);
+				_point.x = x - int(camera.scroll.x*scrollFactor.x) - offset.x;
+				_point.y = y - int(camera.scroll.y*scrollFactor.y) - offset.y;
 				_point.x += (_point.x > 0)?0.0000001:-0.0000001;
 				_point.y += (_point.y > 0)?0.0000001:-0.0000001;
 				


### PR DESCRIPTION
This pull request fixes the offset by one in STYLE_LOCKON camera mode by replacing `ceil()` with `floor()` for the `targetX` and `targetY` adjustmentns. As pointed out [here](https://github.com/FlixelCommunity/flixel/pull/179#issuecomment-27531753), the use of `floor()` fixes the problem. This change does not interfere with the camera jittering fix, which remains in place and working. 
