### PR TITLE
Refactor and fix `FixCamera#follow()`

### DIFF
--- a/src/org/flixel/FlxCamera.as
+++ b/src/org/flixel/FlxCamera.as
@@ -386,15 +386,13 @@ package org.flixel
 		public function follow(Target:FlxObject, Style:uint=STYLE_LOCKON):void
 		{
 			target = Target;
-			var w:Number = 0;
-			var h:Number = 0;
 			
 			switch(Style)
 			{
 				case STYLE_PLATFORMER:
-					w = width/8;
-					h = height/3;
-					deadzone = new FlxRect((width-w)/2,(height-h)/2 - h*0.25,w,h);
+					var cameraPaddingX:Number = width/8;
+					var cameraPaddingY:Number = height/3;
+					deadzone = new FlxRect((width-cameraPaddingX)/2,(height-cameraPaddingY)/2 - cameraPaddingY*0.25,cameraPaddingX,cameraPaddingY);
 					break;
 				case STYLE_TOPDOWN:
 				case STYLE_TOPDOWN_TIGHT:
@@ -405,10 +403,10 @@ package org.flixel
 				case STYLE_LOCKON:
 					if (target != null) 
 					{	
-						w = target.width;
-						h = target.height;
+						var targetWidth:Number = target.width;
+						var targetHeight:Number = target.height;
 					}
-					deadzone = new FlxRect((width-w)/2,(height-h)/2 - h * 0.25,w,h);
+					deadzone = new FlxRect((width-targetWidth)/2,(height-targetHeight)/2 - targetHeight * 0.25,targetWidth,targetHeight);
 					break;
 				default:
 					deadzone = null;

--- a/src/org/flixel/FlxCamera.as
+++ b/src/org/flixel/FlxCamera.as
@@ -402,7 +402,7 @@ package org.flixel
 					break;
 				case STYLE_TOPDOWN:
 				case STYLE_TOPDOWN_TIGHT:
-					var tdTightness:Number = (Style == TOPDOWN_TIGHT) ? 8 : 4;
+					var tdTightness:Number = (Style == STYLE_TOPDOWN_TIGHT) ? 8 : 4;
 					var tdHelper:Number = FlxU.max(width,height)/tdTightness;
 					deadzone = new FlxRect((width-tdHelper)/2,(height-tdHelper)/2,tdHelper,tdHelper);
 					break;
@@ -412,6 +412,8 @@ package org.flixel
 					deadzone = new FlxRect((width-targetWidth)/2,(height-targetHeight)/2,targetWidth,targetHeight);
 					break;
 				default:
+					FlxG.log("[FlxCamera#follow()] WARNING: Invalid follow style of value: " + String(Style) + "'. Defaulting to centering on the target.");
+					target = null;
 					deadzone = null;
 					break;
 			}

--- a/src/org/flixel/FlxCamera.as
+++ b/src/org/flixel/FlxCamera.as
@@ -387,6 +387,12 @@ package org.flixel
 		{
 			target = Target;
 			
+			if (target == null)
+			{
+				deadzone = null;
+				return;
+			}
+			
 			switch(Style)
 			{
 				case STYLE_PLATFORMER:
@@ -401,11 +407,8 @@ package org.flixel
 					deadzone = new FlxRect((width-tdHelper)/2,(height-tdHelper)/2,tdHelper,tdHelper);
 					break;
 				case STYLE_LOCKON:
-					if (target != null) 
-					{	
-						var targetWidth:Number = target.width;
-						var targetHeight:Number = target.height;
-					}
+					var targetWidth:Number = target.width;
+					var targetHeight:Number = target.height;
 					deadzone = new FlxRect((width-targetWidth)/2,(height-targetHeight)/2 - targetHeight * 0.25,targetWidth,targetHeight);
 					break;
 				default:

--- a/src/org/flixel/FlxCamera.as
+++ b/src/org/flixel/FlxCamera.as
@@ -409,7 +409,7 @@ package org.flixel
 				case STYLE_LOCKON:
 					var targetWidth:Number = target.width;
 					var targetHeight:Number = target.height;
-					deadzone = new FlxRect((width-targetWidth)/2,(height-targetHeight)/2 - targetHeight * 0.25,targetWidth,targetHeight);
+					deadzone = new FlxRect((width-targetWidth)/2,(height-targetHeight)/2,targetWidth,targetHeight);
 					break;
 				default:
 					deadzone = null;

--- a/src/org/flixel/FlxCamera.as
+++ b/src/org/flixel/FlxCamera.as
@@ -386,7 +386,6 @@ package org.flixel
 		public function follow(Target:FlxObject, Style:uint=STYLE_LOCKON):void
 		{
 			target = Target;
-			var helper:Number;
 			var w:Number = 0;
 			var h:Number = 0;
 			
@@ -398,12 +397,10 @@ package org.flixel
 					deadzone = new FlxRect((width-w)/2,(height-h)/2 - h*0.25,w,h);
 					break;
 				case STYLE_TOPDOWN:
-					helper = FlxU.max(width,height)/4;
-					deadzone = new FlxRect((width-helper)/2,(height-helper)/2,helper,helper);
-					break;
 				case STYLE_TOPDOWN_TIGHT:
-					helper = FlxU.max(width,height)/8;
-					deadzone = new FlxRect((width-helper)/2,(height-helper)/2,helper,helper);
+					var tdTightness:Number = (Style == TOPDOWN_TIGHT) ? 8 : 4;
+					var tdHelper:Number = FlxU.max(width,height)/tdTightness;
+					deadzone = new FlxRect((width-tdHelper)/2,(height-tdHelper)/2,tdHelper,tdHelper);
 					break;
 				case STYLE_LOCKON:
 					if (target != null) 


### PR DESCRIPTION
So sorry I procrastinated this, I finally sat down and read through how `FlxCamera` handles following targets (and it was much more simple than I thought it would be).

This pull request fixes [the last tiny error with `FlxCamera`](https://github.com/FlixelCommunity/flixel/pull/189#issuecomment-28607960) (and I now understand why that `*0.25` part was accidentally included), but also is tidies up `FlxCamera#follow()` by merging similar camera styles and renaming variable names to be more descriptive.

I have tested and confirmed that it works as expected, at least in [Mode](https://github.com/FlixelCommunity/Mode). If anyone else wants to test the resulting SWC:
- https://github.com/FlixelCommunity/flixel/releases/download/untagged-e6aefb20eafd21679aca/flixel-v2.55-183-g692a614.swc
