### PR TITLE
Removing equality sign from _accumulator in FlxGame

### DIFF
--- a/src/org/flixel/FlxGame.as
+++ b/src/org/flixel/FlxGame.as
@@ -445,7 +445,7 @@ package org.flixel
 					_accumulator += elapsedMS;
 					if(_accumulator > _maxAccumulation)
 						_accumulator = _maxAccumulation;
-					while(_accumulator >= _step)
+					while(_accumulator > _step)
 					{
 						step();
 						_accumulator = _accumulator - _step; 


### PR DESCRIPTION
Hi! As far as I know, this is a known fix for the FlxGame class. Removing the equality sign prevents some frames from being erroneously skipped, and could result in smoother games.
I was wondering: why is it not in the updated community version?
Also, I know that what I am going to do is extremely but practice, but: I have also issues this pool requests for the power tools, which are also maintained by this account: https://github.com/FlixelCommunity/Flixel-Power-Tools/pull/22
Although probably the FPT are not so used anymore, those bugs are pretty big, so it would be cool if someone could merge them and prevent characters from moving at huge speeds with no reason :D
Thank you in advance, I promise I will work on some scheduled issue next time!
