### PR TITLE
Add 'FlxRandom' pseudo-random number generator

### DIFF
--- a/src/flixel/FlxCamera.as
+++ b/src/flixel/FlxCamera.as
@@ -374,9 +374,9 @@ package flixel
 				else
 				{
 					if((_fxShakeDirection == SHAKE_BOTH_AXES) || (_fxShakeDirection == SHAKE_HORIZONTAL_ONLY))
-						_fxShakeOffset.x = (FlxG.random()*_fxShakeIntensity*width*2-_fxShakeIntensity*width)*_zoom;
+						_fxShakeOffset.x = FlxG.random.float(-_fxShakeIntensity, _fxShakeIntensity)*width*_zoom;
 					if((_fxShakeDirection == SHAKE_BOTH_AXES) || (_fxShakeDirection == SHAKE_VERTICAL_ONLY))
-						_fxShakeOffset.y = (FlxG.random()*_fxShakeIntensity*height*2-_fxShakeIntensity*height)*_zoom;
+						_fxShakeOffset.y = FlxG.random.float(-_fxShakeIntensity, _fxShakeIntensity)*height*_zoom;
 				}
 			}
 		}

--- a/src/flixel/FlxG.as
+++ b/src/flixel/FlxG.as
@@ -1,5 +1,6 @@
 package flixel
 {
+	import flixel.util.FlxRandom;
 	import flixel.util.FlxU;
 	import flixel.system.FlxSound;
 	import flixel.input.keyboard.Keyboard;
@@ -146,10 +147,6 @@ package flixel
 		 */
 		static public var mobile:Boolean; 
 		/**
-		 * The global random number generator seed (for deterministic behavior in recordings and saves).
-		 */
-		static public var globalSeed:Number;
-		/**
 		 * <code>FlxG.levels</code> and <code>FlxG.scores</code> are generic
 		 * global variables that can be used for various cross-state stuff.
 		 */
@@ -217,6 +214,11 @@ package flixel
 		 * DebugPathDisplay, and TimerManager.
 		 */
 		 static public var plugins:Array;
+		
+		/**
+		 * The global instance of the deterministic 'FlxRandom' pseudo-random number generator.
+		 */
+		 static public var random:FlxRandom;
 		 
 		/**
 		 * Set this hook to get a callback whenever the volume changes.
@@ -250,6 +252,21 @@ package flixel
 		{
 			if((_game != null) && (_game._debugger != null))
 				_game._debugger.log.add((Data == null)?"ERROR: null object":((Data is Array)?FlxU.formatArray(Data as Array):Data.toString()));
+		}
+		
+		/**
+		 * Warn the developer or user about a deprecated member.
+		 *
+		 * Mostly a helper function for the existing 
+		 * 
+		 * @param	OldMember	The name of the old, depricated member.
+		 * @param	NewMember	The name of the new replacement member. Optional.
+		 */
+		static public function warnDeprecated(OldMember:String, NewMember:String):void
+		{
+			var message:String = "WARNING: The member '" + OldMember + "' has been deprecated and may be removed in a future release.";
+			if (NewMember) { message += " Please use '" + NewMember + "' intead."; }
+			FlxG.log(message);
 		}
 		
 		/**
@@ -335,70 +352,6 @@ package flixel
 			var fsh:uint = FlxG.height*FlxG.camera.zoom;
 			FlxG.camera.x = (FlxG.stage.fullScreenWidth - fsw)/2;
 			FlxG.camera.y = (FlxG.stage.fullScreenHeight - fsh)/2;
-		}
-		
-		/**
-		 * Generates a random number.  Deterministic, meaning safe
-		 * to use if you want to record replays in random environments.
-		 * 
-		 * @return	A <code>Number</code> between 0 and 1.
-		 */
-		static public function random():Number
-		{
-			return globalSeed = FlxU.srand(globalSeed);
-		}
-		
-		/**
-		 * Shuffles the entries in an array into a new random order.
-		 * <code>FlxG.shuffle()</code> is deterministic and safe for use with replays/recordings.
-		 * HOWEVER, <code>FlxU.shuffle()</code> is NOT deterministic and unsafe for use with replays/recordings.
-		 * 
-		 * @param	A				A Flash <code>Array</code> object containing...stuff.
-		 * @param	HowManyTimes	How many swaps to perform during the shuffle operation.  Good rule of thumb is 2-4 times as many objects are in the list.
-		 * 
-		 * @return	The same Flash <code>Array</code> object that you passed in in the first place.
-		 */
-		static public function shuffle(Objects:Array,HowManyTimes:uint):Array
-		{
-			var i:uint = 0;
-			var index1:uint;
-			var index2:uint;
-			var object:Object;
-			while(i < HowManyTimes)
-			{
-				index1 = FlxG.random()*Objects.length;
-				index2 = FlxG.random()*Objects.length;
-				object = Objects[index2];
-				Objects[index2] = Objects[index1];
-				Objects[index1] = object;
-				i++;
-			}
-			return Objects;
-		}
-		
-		/**
-		 * Fetch a random entry from the given array.
-		 * Will return null if random selection is missing, or array has no entries.
-		 * <code>FlxG.getRandom()</code> is deterministic and safe for use with replays/recordings.
-		 * HOWEVER, <code>FlxU.getRandom()</code> is NOT deterministic and unsafe for use with replays/recordings.
-		 * 
-		 * @param	Objects		A Flash array of objects.
-		 * @param	StartIndex	Optional offset off the front of the array. Default value is 0, or the beginning of the array.
-		 * @param	Length		Optional restriction on the number of values you want to randomly select from.
-		 * 
-		 * @return	The random object that was selected.
-		 */
-		static public function getRandom(Objects:Array,StartIndex:uint=0,Length:uint=0):Object
-		{
-			if(Objects != null)
-			{
-				var l:uint = Length;
-				if((l == 0) || (l > Objects.length - StartIndex))
-					l = Objects.length - StartIndex;
-				if(l > 0)
-					return Objects[StartIndex + uint(FlxG.random()*l)];
-			}
-			return null;
 		}
 		
 		/**
@@ -1153,7 +1106,7 @@ package flixel
 			FlxG.paused = false;
 			FlxG.timeScale = 1.0;
 			FlxG.elapsed = 0;
-			FlxG.globalSeed = Math.random();
+			FlxG.random = new FlxRandom();
 			FlxG.worldBounds = new FlxRect(-10,-10,FlxG.width+20,FlxG.height+20);
 			FlxG.worldDivisions = 6;
 			var debugPathDisplay:DebugPathDisplay = FlxG.getPlugin(DebugPathDisplay) as DebugPathDisplay;
@@ -1268,5 +1221,67 @@ package flixel
 					plugin.draw();
 			}
 		}
+		
+		
+		/*     --- Deprecated members in Flixel v2.57 ---     */
+		/*  To be removed after developers have had time to adjust to the new changes. */
+		
+		/**
+		 * The global random number generator seed (for deterministic behavior in recordings and saves).
+		 * 
+		 * @deprecated This property is deprecated. Use <code>FlxG.random.seed</code> instead.
+		 */
+		static public function get globalSeed():Number
+		{
+			FlxG.warnDeprecated('FlxG.globalSeed', 'FlxG.random.seed');
+			return FlxG.random.seed;
+		}
+		/**
+		 * @private
+		 * 
+		 * @deprecated This property is deprecated. Use <code>FlxG.random.seed</code> instead.
+		 */
+		static public function set globalSeed(value:Number):void
+		{
+			FlxG.warnDeprecated('FlxG.globalSeed', 'FlxG.random.seed');
+			FlxG.random.seed = value;
+		}
+		
+		/**
+		 * Shuffles the entries in an array into a new random order.
+		 * Uses <code>FlxG.random.shuffle()</code> and is deterministic and safe for use with replays/recordings.
+		 * 
+		 * @param	Objects			A Flash <code>Array</code> object containing...stuff.
+		 * @param	HowManyTimes	How many swaps to perform during the shuffle operation. Deprecated; instead, all items in the array are shuffled once.
+		 * 
+		 * @return	The same Flash <code>Array</code> object that you passed in in the first place.
+		 * 
+		 * @deprecated This property is deprecated. Use <code>FlxG.random.shuffle()</code> instead.
+		 */
+		static public function shuffle(Objects:Array,HowManyTimes:uint):Array
+		{
+			FlxG.warnDeprecated('FlxG.shuffle()', 'FlxG.random.shuffle()');
+			return FlxG.random.shuffle(Objects, false);
+		}
+		
+		/**
+		 * Fetch a random entry from the given array.
+		 * Will return null if random selection is missing, or array has no entries.
+		 * Uses <code>FlxG.random.item()</code> and is deterministic and safe for use with replays/recordings.
+		 * 
+		 * @param	Objects		A Flash array of objects.
+		 * @param	StartIndex	Optional offset off the front of the array. Default value is 0, or the beginning of the array.
+		 * @param	Length		Optional restriction on the number of values you want to randomly select from.
+		 * 
+		 * @return	The random object that was selected.
+		 * 
+		 * @deprecated This property is deprecated. Use <code>FlxG.random.item()</code> instead.
+		 */
+		static public function getRandom(Objects:Array,StartIndex:uint=0,Length:uint=0):Object
+		{
+			FlxG.warnDeprecated('FlxG.getRandom()', 'FlxG.random.item()');
+			return FlxG.random.item(Objects, StartIndex, Length);
+		}
+		
 	}
 }

--- a/src/flixel/FlxGame.as
+++ b/src/flixel/FlxGame.as
@@ -521,7 +521,7 @@ package flixel
 			if(_recordingRequested)
 			{
 				_recordingRequested = false;
-				_replay.create(FlxG.globalSeed);
+				_replay.create(FlxG.random.seed);
 				_recording = true;
 				if(_debugger != null)
 				{
@@ -533,7 +533,7 @@ package flixel
 			{
 				_replayRequested = false;
 				_replay.rewind();
-				FlxG.globalSeed = _replay.seed;
+				FlxG.random.seed = _replay.seed;
 				if(_debugger != null)
 					_debugger.vcr.playing();
 				_replaying = true;

--- a/src/flixel/FlxGroup.as
+++ b/src/flixel/FlxGroup.as
@@ -538,7 +538,7 @@ package flixel
 		{
 			if(Length == 0)
 				Length = length;
-			return FlxG.getRandom(members,StartIndex,Length) as FlxBasic;
+			return FlxG.random.item(members,StartIndex,Length) as FlxBasic;
 		}
 		
 		/**

--- a/src/flixel/FlxSprite.as
+++ b/src/flixel/FlxSprite.as
@@ -685,7 +685,7 @@ package flixel
 		public function randomFrame():void
 		{
 			_curAnim = null;
-			trySetIndex(int(FlxG.random()*numFrames)); // Shouldn't ever throw an error
+			trySetIndex(FlxG.random.integer(0, numFrames-1)); // Shouldn't ever throw an error
 		}
 		
 		/**

--- a/src/flixel/effects/particles/FlxEmitter.as
+++ b/src/flixel/effects/particles/FlxEmitter.as
@@ -177,17 +177,15 @@ package flixel.effects.particles
 				totalFrames = sprite.numFrames;
 				sprite.destroy();
 			}
-
-			var randomFrame:uint;
-			var particle:FlxParticle;
+			
 			var i:uint = 0;
 			while(i < Quantity)
 			{
-				particle = new particleClass() as FlxParticle;
+				var particle:FlxParticle = new particleClass() as FlxParticle;
 				
 				if(Multiple)
 				{
-					randomFrame = FlxG.random()*totalFrames;
+					var randomFrame:uint = FlxG.random.integer(0, totalFrames-1);
 					if(BakedRotations > 0)
 						particle.loadRotatedGraphic(Graphics,BakedRotations,randomFrame);
 					else
@@ -297,25 +295,16 @@ package flixel.effects.particles
 			var particle:FlxParticle = recycle(particleClass) as FlxParticle;
 			particle.lifespan = lifespan;
 			particle.elasticity = bounce;
-			particle.reset(x - (particle.width>>1) + FlxG.random()*width, y - (particle.height>>1) + FlxG.random()*height);
+			particle.reset(x - (particle.width>>1) + FlxG.random.float(0, width), y - (particle.height>>1) + FlxG.random.float(0, height));
 			particle.visible = true;
 			
-			if(minParticleSpeed.x != maxParticleSpeed.x)
-				particle.velocity.x = minParticleSpeed.x + FlxG.random()*(maxParticleSpeed.x-minParticleSpeed.x);
-			else
-				particle.velocity.x = minParticleSpeed.x;
-			if(minParticleSpeed.y != maxParticleSpeed.y)
-				particle.velocity.y = minParticleSpeed.y + FlxG.random()*(maxParticleSpeed.y-minParticleSpeed.y);
-			else
-				particle.velocity.y = minParticleSpeed.y;
+			particle.velocity.x = FlxG.random.float(minParticleSpeed.x, maxParticleSpeed.x);
+			particle.velocity.y = FlxG.random.float(minParticleSpeed.y, maxParticleSpeed.y);
 			particle.acceleration.y = gravity;
 			
-			if(minRotation != maxRotation)
-				particle.angularVelocity = minRotation + FlxG.random()*(maxRotation-minRotation);
-			else
-				particle.angularVelocity = minRotation;
+			particle.angularVelocity = FlxG.random.float(minRotation, maxRotation);
 			if(particle.angularVelocity != 0)
-				particle.angle = FlxG.random()*360-180;
+				particle.angle = FlxG.random.float(-180, 180);
 			
 			particle.drag.x = particleDrag.x;
 			particle.drag.y = particleDrag.y;

--- a/src/flixel/tile/FlxTileblock.as
+++ b/src/flixel/tile/FlxTileblock.as
@@ -76,7 +76,7 @@ package flixel.tile
 				column = 0;
 				while(column < widthInTiles)
 				{
-					if(FlxG.random()*total > Empties)
+					if(FlxG.random.float()*total > Empties)
 					{
 						sprite.randomFrame();
 						sprite.drawFrame();

--- a/src/flixel/util/FlxRandom.as
+++ b/src/flixel/util/FlxRandom.as
@@ -1,24 +1,28 @@
 package flixel.util
 {
 	import flixel.FlxG;
+	import flixel.util.FlxU;
 	
 	/**
 	 * A class containing a set of functions for random generation.
 	 * 
-	 * There are no static methods for retrieving random numbers; either create your own instance of the FlxRandom class, or use the 'FlxG.random' instance.
+	 * @see 	http://en.wikipedia.org/wiki/Linear_congruential_generator
+	 * @see 	Stephen K. Park and Keith W. Miller and Paul K. Stockmeyer (1988). "Technical Correspondence". Communications of the ACM 36 (7): 105–110.
 	 * 
 	 * Contains modified code from the following libraries:
 	 *  - HaxeFlixel (released under the MIT License) <https://github.com/HaxeFlixel/flixel>
 	 *  - AS3Libs by Grant Skinner (released under the MIT License) <https://github.com/gskinner/AS3Libs>
+	 * 
+	 * There are no static methods for retrieving random numbers; either create your own instance of the FlxRandom class, or use the <code>FlxG.random</code> instance.
 	 */
 	public class FlxRandom
 	{
 		/**
-		 * Creates a new instance of the FlxRandom class.
+		 * Creates a new instance of the <code>FlxRandom</code> class.
 		 * 
-		 * If you want, you can set the seed with an integer between  inclusive. However, FlxG automatically sets this with a new random seed when starting your game.
+		 * If you want, you can set the seed with an integer between  inclusive. However, <code>FlxG</code> automatically sets this with a new random seed when starting your game.
 		 *
-		 * @param	seed	The seed you wish to use to start off the random number generator; needs to be a value between MIN_SEED (1) and MAX_SEED (2,147,483,646). If the value is set to 0, a random starting seed will be chosen.
+		 * @param	seed	The seed you wish to use to start off the random number generator; needs to be a value between <code>MIN_SEED</code> (<code>1</code>) and <code>MAX_SEED</code> (<code>2,147,483,646</code>). If the value is set to <code>0</code>, a random starting seed will be chosen.
 		 */
 		public function FlxRandom(seed:uint = 0)
 		{
@@ -45,7 +49,7 @@ package flixel.util
 		protected var _currentSeed:int = 0;
 		
 		/**
-		 * The original seed value used to start off the pseudo-random number generator. When set, will also reset the value of 'currentSeed'.
+		 * The original seed value used to start off the pseudo-random number generator. When set, will also reset the value of <code>currentSeed</code>.
 		 */
 		public function get seed():uint
 		{
@@ -69,7 +73,7 @@ package flixel.util
 		}
 		
 		/**
-		 * The current "state" of the original seed. This value changes each time the 'generate()' method is called.
+		 * The current "state" of the original seed. This value changes each time the <code>generate()</code> method is called.
 		 */
 		public function get currentSeed():uint 
 		{
@@ -77,7 +81,7 @@ package flixel.util
 		}
 		
 		/**
-		 * Resets the current "state" of the seed (represented by the 'currentSeed' value) to the original 'seed' value.
+		 * Resets the current "state" of the seed (represented by the <code>currentSeed</code> value) to the original <code>seed</code> value.
 		 */
 		public function resetSeed():void
 		{
@@ -101,10 +105,7 @@ package flixel.util
 		
 		/**
 		 * Constants used in the pseudorandom number generation equation.
-		 * These are the constants suggested by the revised MINSTD pseudorandom number generator, and they use the full range of possible integer values.
-		 * 
-		 * @see 	http://en.wikipedia.org/wiki/Linear_congruential_generator
-		 * @see 	Stephen K. Park and Keith W. Miller and Paul K. Stockmeyer (1988). "Technical Correspondence". Communications of the ACM 36 (7): 105–110.
+		 * These are the constants suggested by the revised "minimum standard" pseudo-random number generator, and result in an integer between <code>1</code> and <code>0x7FFFFFFF-1</code> (see <code>MIN_SEED</code> and <code>MAX_SEED</code> values)
 		 */
 		protected const MULTIPLIER:int = 48271;
 		protected const MODULUS:int = 2147483647; // 0x7FFFFFFF (31 bit integer)
@@ -113,7 +114,7 @@ package flixel.util
 		 * Internal method to quickly generate a pseudorandom number. Used only by other functions of this class.
 		 * Also updates the current seed, which will then be used to generate the next pseudorandom number.
 		 * 
-		 * @return	A new pseudorandom number between 0 inclusive and 1 exclusive.
+		 * @return	A new pseudorandom number between <code>0</code> inclusive and <code>1</code> exclusive.
 		 */
 		protected function generate():Number
 		{
@@ -122,11 +123,11 @@ package flixel.util
 		}
 		
 		/**
-		 * Returns a pseudo-random float (also known as Number) value between 'min' inclusive and 'max' exclusive.
+		 * Returns a pseudo-random float (also known as <code>Number</code> in ActionScript 3) value between <code>min</code> inclusive and <code>max</code> exclusive.
 		 * That is <code>[min, max)</code>
 		 * 
-		 * @param	min			The minimum value that should be returned. 0 by default.
-		 * @param	max			The maximum value that should be returned. 1 by default.
+		 * @param	min			The minimum value that should be returned. <code>0</code> by default.
+		 * @param	max			The maximum value that should be returned. <code>1</code> by default.
 		 */
 		public function float(min:Number = 0, max:Number = 1):Number
 		{
@@ -135,12 +136,12 @@ package flixel.util
 		}
 		
 		/**
-		 * Returns either a 'true' or 'false' based on the chance value.
-		 * A chance value of 0.5 means a 50% chance of 'true' being returned.
-		 * A chance value of 0.8 means an 80% chance of 'true' being returned.
-		 * A chance value of 0 means 'false' will always be returned.
+		 * Returns either a <code>true</code> or <code>false</code> based on the chance value.
+		 * A chance value of 0.5 means a 50% chance of <code>true</code> being returned.
+		 * A chance value of 0.8 means an 80% chance of <code>true</code> being returned.
+		 * A chance value of 0 means <code>false</code> will always be returned.
 		 * 
-		 * @param	chance		The odds of returning 'true'. 0.5 (50% chance) by default.
+		 * @param	chance		The odds of returning <code>true</code>. 0.5 (50% chance) by default.
 		 */
 		public function boolean(chance:Number = 0.5):Boolean
 		{
@@ -148,13 +149,13 @@ package flixel.util
 		}
 		
 		/**
-		 * Returns either a '1' or '-1' based on the chance value.
-		 * A chance value of 0.8 means an 80% chance of '1' being returned.
-		 * A chance value of 0 means 'false' will always be returned.
+		 * Returns either a <code>1</code> or <code>-1</code> based on the chance value.
+		 * A chance value of <code>0.8</code> means an 80% chance of <code>1</code> being returned.
+		 * A chance value of <code>0</code> means <code>false</code> will always be returned.
 		 * 
-		 * Recommended to be used with the '*' operator: <code>score += random.sign(0.8) * 10;</code> will result in an 80% chance of '10' and a 20% chance of '-10'.
+		 * Recommended to be used with the <code>*</code> operator: <code>score += random.sign(0.8) * 10;</code> will result in an 80% chance of <code>10</code> and a 20% chance of <code>-10</code>.
 		 * 
-		 * @param	chance		The odds of returning '1'. 0.5 (50% chance) by default.
+		 * @param	chance		The odds of returning <code>1</code>. <code>0.5</code> (50% chance) by default.
 		 */
 		public function sign(chance:Number = 0.5):int
 		{
@@ -162,12 +163,12 @@ package flixel.util
 		}
 		
 		/**
-		 * Returns either a '1' or '0' based on the chance value.
-		 * A chance value of 0.5 means a 50% chance of '1' being returned.
-		 * A chance value of 0.8 means an 80% chance of '1' being returned.
-		 * A chance value of 0 means '0' will always be returned.
+		 * Returns either a <code>1</code> or <code>0</code> based on the chance value.
+		 * A chance value of 0.5 means a 50% chance of <code>1</code> being returned.
+		 * A chance value of 0.8 means an 80% chance of <code>1</code> being returned.
+		 * A chance value of 0 means <code>0</code> will always be returned.
 		 * 
-		 * @param	chance		The odds of returning '1'. 0.5 (50% chance) by default.
+		 * @param	chance		The odds of returning <code>1</code>. <code>0.5</code> (50% chance) by default.
 		 */
 		public function bit(chance:Number=0.5):int 
 		{
@@ -175,24 +176,24 @@ package flixel.util
 		}
 		
 		/**
-		 * Returns a pseudo-random integer between the specified range 'min' and 'max', both inclusive.
+		 * Returns a pseudo-random integer between the specified range <code>min</code> and <code>max</code>, both inclusive.
 		 * That is <code>[min, max]</code>.
 		 * 
-		 * If no 'max' value is specified, a value between '0' and the first argument will be returned instead.
+		 * If no <code>max</code> value is specified, a value between <code>0</code> and the first argument will be returned instead.
 		 * 
 		 * @param	min			The minimum value that should be returned. Required.
-		 * @param	max			The maximum value that should be returned. If omitted, the first parameter will instead be treated as the 'max' value.
+		 * @param	max			The maximum value that should be returned. If omitted, the first parameter will instead be treated as the <code>max</code> value.
 		 */
 		public function integer(min:Number, max:Number = NaN):int
 		{
 			if (isNaN(max)) { max = min; min = 0; }
 			// Need to use floor instead of bit shift to work properly with negative values:
-			return Math.floor(float(min, max + 1));
+			return FlxU.floor(float(min, max + 1));
 		}
 		
 		/**
 		 * Select a random item from the specified array. Does not modify the array.
-		 * Will return 'null' if random selection is missing, or array has no entries.
+		 * Will return <code>null</code> if random selection is missing, or array has no entries.
 		 * 
 		 * @param	array			The array to pick the item from.
 		 * @param	startIndex		Optional offset off the front of the array. Default value is 0, or the beginning of the array.
@@ -213,7 +214,7 @@ package flixel.util
 		 * Shuffles the entire array into a new pseudo-random order.
 		 * 
 		 * @param	array			An array to shuffle.
-		 * @param	modifyArray		Whether or not to modify the passed in array. If set to 'false', a new array with the same values will be returned instead of modifying the original one.
+		 * @param	modifyArray		Whether or not to modify the passed in array. If set to <code>false</code>, a new array with the same values will be returned instead of modifying the original one.
 		 * @return	The newly shuffled array.
 		 */
 		public function shuffle(array:Array, modifyArray:Boolean = true):Array
@@ -221,7 +222,7 @@ package flixel.util
 			if (!modifyArray)
 				{ array = array.slice(); }
 			
-			var len = array.length;
+			var len:int = array.length;
 			for (var i:uint = 0; i < len; i++)
 			{
 				var j:uint = uint(len * generate());
@@ -237,10 +238,10 @@ package flixel.util
 		/**
 		 * Chooses a random color, or greyscale shade.
 		 * 
-		 * NOTE: For non-32 bit colors, you may want to set the 'alpha' to '0' to return the color as '0xRRGGBB', though, the alpha bits are usually ignored in practice if they aren't used by a certain function.
+		 * NOTE: For non-32 bit colors, you may want to set the <code>alpha</code> to <code>0</code> to return the color as <code>0xRRGGBB</code>, though, the alpha bits are usually ignored in practice if they aren't used by a certain function.
 		 * 
-		 * @param	alpha			The alpha value, from 0 (transparent) to 1 (opaque)
-		 * @param	greyScale		Whether or not to return a shade of grey instead of a color. Defaults to 'false'.
+		 * @param	alpha			The alpha value, from <code>0 (transparent) to <code>1 (opaque)
+		 * @param	greyScale		Whether or not to return a shade of grey instead of a color. Defaults to <code>false</code>.
 		 * @return	The 32 bit color in the format 0xAARRGGBB
 		 */
 		public function color(alpha:Number = 1, greyScale:Boolean = false):uint
@@ -249,10 +250,10 @@ package flixel.util
 			if (alpha < 0) { alpha = 0; }
 			var alphaHex:uint = uint(0xFF * alpha);
 			
-			// Since 'generate()' can never return '1', we will never get exactly pure white (0xFFFFFF). Oh well, we can come close.
+			// Since `generate()` can never return `1`, we will never get exactly pure white (0xFFFFFF). Oh well, we can come close.
 			if (greyScale)
 			{
-				var greyHex = uint(0xFF * generate());
+				var greyHex:uint = uint(0xFF * generate());
 				return alphaHex << 24 | greyHex << 16 | greyHex << 8 | greyHex << 0;
 			}
 			else

--- a/src/flixel/util/FlxRandom.as
+++ b/src/flixel/util/FlxRandom.as
@@ -192,12 +192,21 @@ package flixel.util
 		
 		/**
 		 * Select a random item from the specified array. Does not modify the array.
+		 * Will return 'null' if random selection is missing, or array has no entries.
 		 * 
 		 * @param	array			The array to pick the item from.
+		 * @param	startIndex		Optional offset off the front of the array. Default value is 0, or the beginning of the array.
+		 * @param	length			Optional restriction on the number of values you want to randomly select from.
 		 */
-		public function item(array:Array):*
+		public function item(array:Array, startIndex:uint = 0, length:uint = 0):*
 		{
-			return array[uint(array.length * generate())];
+			if ((length == 0) || (length > (array.length - startIndex)))
+				{ length = (array.length - startIndex); }
+			
+			if (length > 0)
+				{ return array[startIndex + uint(length * generate())]; }
+			
+			return null;
 		}
 		
 		/**
@@ -223,6 +232,33 @@ package flixel.util
 				array[i] = item;
 			}
 			return array;
+		}
+		
+		/**
+		 * Chooses a random color, or greyscale shade.
+		 * 
+		 * NOTE: For non-32 bit colors, you may want to set the 'alpha' to '0' to return the color as '0xRRGGBB', though, the alpha bits are usually ignored in practice if they aren't used by a certain function.
+		 * 
+		 * @param	alpha			The alpha value, from 0 (transparent) to 1 (opaque)
+		 * @param	greyScale		Whether or not to return a shade of grey instead of a color. Defaults to 'false'.
+		 * @return	The 32 bit color in the format 0xAARRGGBB
+		 */
+		public function color(alpha:Number = 1, greyScale:Boolean = false):uint
+		{
+			if (alpha > 1) { alpha = 1; }
+			if (alpha < 0) { alpha = 0; }
+			var alphaHex:uint = uint(0xFF * alpha);
+			
+			// Since 'generate()' can never return '1', we will never get exactly pure white (0xFFFFFF). Oh well, we can come close.
+			if (greyScale)
+			{
+				var greyHex = uint(0xFF * generate());
+				return alphaHex << 24 | greyHex << 16 | greyHex << 8 | greyHex << 0;
+			}
+			else
+			{
+				return alphaHex << 24 | uint(0xFFFFFF * generate());
+			}
 		}
 		
 	}

--- a/src/flixel/util/FlxRandom.as
+++ b/src/flixel/util/FlxRandom.as
@@ -6,14 +6,14 @@ package flixel.util
 	/**
 	 * A class containing a set of functions for random generation.
 	 * 
-	 * @see 	http://en.wikipedia.org/wiki/Linear_congruential_generator
-	 * @see 	Stephen K. Park and Keith W. Miller and Paul K. Stockmeyer (1988). "Technical Correspondence". Communications of the ACM 36 (7): 105–110.
+	 * There are no static methods for retrieving random numbers; either create your own instance of the FlxRandom class, or use the <code>FlxG.random</code> instance.
 	 * 
 	 * Contains modified code from the following libraries:
-	 *  - HaxeFlixel (released under the MIT License) <https://github.com/HaxeFlixel/flixel>
-	 *  - AS3Libs by Grant Skinner (released under the MIT License) <https://github.com/gskinner/AS3Libs>
+	 *  - HaxeFlixel (released under the MIT License) - https://github.com/HaxeFlixel/flixel
+	 *  - AS3Libs by Grant Skinner (released under the MIT License) - https://github.com/gskinner/AS3Libs
 	 * 
-	 * There are no static methods for retrieving random numbers; either create your own instance of the FlxRandom class, or use the <code>FlxG.random</code> instance.
+	 * @see 	http://en.wikipedia.org/wiki/Linear_congruential_generator
+	 * @see 	Stephen K. Park and Keith W. Miller and Paul K. Stockmeyer (1988). "Technical Correspondence". Communications of the ACM 36 (7): 105–110.
 	 */
 	public class FlxRandom
 	{

--- a/src/flixel/util/FlxRandom.as
+++ b/src/flixel/util/FlxRandom.as
@@ -6,6 +6,10 @@ package flixel.util
 	 * A class containing a set of functions for random generation.
 	 * 
 	 * There are no static methods for retrieving random numbers; either create your own instance of the FlxRandom class, or use the 'FlxG.random' instance.
+	 * 
+	 * Contains modified code from the following libraries:
+	 *  - HaxeFlixel (released under the MIT License) <https://github.com/HaxeFlixel/flixel>
+	 *  - AS3Libs by Grant Skinner (released under the MIT License) <https://github.com/gskinner/AS3Libs>
 	 */
 	public class FlxRandom
 	{
@@ -117,6 +121,109 @@ package flixel.util
 			return (_currentSeed / MODULUS);
 		}
 		
+		/**
+		 * Returns a pseudo-random float (also known as Number) value between 'min' inclusive and 'max' exclusive.
+		 * That is <code>[min, max)</code>
+		 * 
+		 * @param	min			The minimum value that should be returned. 0 by default.
+		 * @param	max			The maximum value that should be returned. 1 by default.
+		 */
+		public function float(min:Number = 0, max:Number = 1):Number
+		{
+			if ( (min == 0) && (max == 1) ) { return generate(); } // For performance 
+			else return min + generate() * (max - min);
+		}
+		
+		/**
+		 * Returns either a 'true' or 'false' based on the chance value.
+		 * A chance value of 0.5 means a 50% chance of 'true' being returned.
+		 * A chance value of 0.8 means an 80% chance of 'true' being returned.
+		 * A chance value of 0 means 'false' will always be returned.
+		 * 
+		 * @param	chance		The odds of returning 'true'. 0.5 (50% chance) by default.
+		 */
+		public function boolean(chance:Number = 0.5):Boolean
+		{
+			return (generate() < chance);
+		}
+		
+		/**
+		 * Returns either a '1' or '-1' based on the chance value.
+		 * A chance value of 0.8 means an 80% chance of '1' being returned.
+		 * A chance value of 0 means 'false' will always be returned.
+		 * 
+		 * Recommended to be used with the '*' operator: <code>score += random.sign(0.8) * 10;</code> will result in an 80% chance of '10' and a 20% chance of '-10'.
+		 * 
+		 * @param	chance		The odds of returning '1'. 0.5 (50% chance) by default.
+		 */
+		public function sign(chance:Number = 0.5):int
+		{
+			return (generate() < chance) ? 1 : -1;
+		}
+		
+		/**
+		 * Returns either a '1' or '0' based on the chance value.
+		 * A chance value of 0.5 means a 50% chance of '1' being returned.
+		 * A chance value of 0.8 means an 80% chance of '1' being returned.
+		 * A chance value of 0 means '0' will always be returned.
+		 * 
+		 * @param	chance		The odds of returning '1'. 0.5 (50% chance) by default.
+		 */
+		public function bit(chance:Number=0.5):int 
+		{
+			return (generate() < chance) ? 1 : 0;
+		}
+		
+		/**
+		 * Returns a pseudo-random integer between the specified range 'min' and 'max', both inclusive.
+		 * That is <code>[min, max]</code>.
+		 * 
+		 * If no 'max' value is specified, a value between '0' and the first argument will be returned instead.
+		 * 
+		 * @param	min			The minimum value that should be returned. Required.
+		 * @param	max			The maximum value that should be returned. If omitted, the first parameter will instead be treated as the 'max' value.
+		 */
+		public function integer(min:Number, max:Number = NaN):int
+		{
+			if (isNaN(max)) { max = min; min = 0; }
+			// Need to use floor instead of bit shift to work properly with negative values:
+			return Math.floor(float(min, max + 1));
+		}
+		
+		/**
+		 * Select a random item from the specified array. Does not modify the array.
+		 * 
+		 * @param	array			The array to pick the item from.
+		 */
+		public function item(array:Array):*
+		{
+			return array[uint(array.length * generate())];
+		}
+		
+		/**
+		 * Shuffles the entire array into a new pseudo-random order.
+		 * 
+		 * @param	array			An array to shuffle.
+		 * @param	modifyArray		Whether or not to modify the passed in array. If set to 'false', a new array with the same values will be returned instead of modifying the original one.
+		 * @return	The newly shuffled array.
+		 */
+		public function shuffle(array:Array, modifyArray:Boolean = true):Array
+		{
+			if (!modifyArray)
+				{ array = array.slice(); }
+			
+			var len = array.length;
+			for (var i:uint = 0; i < len; i++)
+			{
+				var j:uint = uint(len * generate());
+				if (j == i) { continue; }
+				
+				var item:* = array[j];
+				array[j] = array[i];
+				array[i] = item;
+			}
+			return array;
+		}
 		
 	}
 }

--- a/src/flixel/util/FlxRandom.as
+++ b/src/flixel/util/FlxRandom.as
@@ -1,0 +1,122 @@
+package flixel.util
+{
+	import flixel.FlxG;
+	
+	/**
+	 * A class containing a set of functions for random generation.
+	 * 
+	 * There are no static methods for retrieving random numbers; either create your own instance of the FlxRandom class, or use the 'FlxG.random' instance.
+	 */
+	public class FlxRandom
+	{
+		/**
+		 * Creates a new instance of the FlxRandom class.
+		 * 
+		 * If you want, you can set the seed with an integer between  inclusive. However, FlxG automatically sets this with a new random seed when starting your game.
+		 *
+		 * @param	seed	The seed you wish to use to start off the random number generator; needs to be a value between MIN_SEED (1) and MAX_SEED (2,147,483,646). If the value is set to 0, a random starting seed will be chosen.
+		 */
+		public function FlxRandom(seed:uint = 0)
+		{
+			if (seed == 0) 
+			{
+				this.randomizeSeed();
+			}
+			else
+			{
+				this.seed = seed;
+			}
+		}
+		
+		/** 
+		 * The smallest allowed value for a seed, based on the current algorithm used for the pseudo-random number generation.
+		 */
+		public static const MIN_SEED:uint = 1;
+		public static const MAX_SEED:uint = 0x7FFFFFFF - 1; // Results in 0x7FFFFFFE, but the -1 makes it a bit clearer I feel.
+		
+		// The original seed that was set by the user
+		protected var _seed:int = 0;
+		
+		// Internal tracker that keeps track of the current value of the seed as it changes with each iteration
+		protected var _currentSeed:int = 0;
+		
+		/**
+		 * The original seed value used to start off the pseudo-random number generator. When set, will also reset the value of 'currentSeed'.
+		 */
+		public function get seed():uint
+		{
+			return _seed;
+		}
+		
+		/**
+		 * @private
+		 */
+		public function set seed(value:uint):void
+		{
+			if ( (value < MIN_SEED) || (value > MAX_SEED) )
+			{
+				FlxG.log("ERROR: Invalid seed value of '" + value + "' passed to 'flixel.util.FlxRandom'. The value must be between '" + MIN_SEED + "' and '" + MAX_SEED + "'.");
+				FlxG.log("To prevent problems with the random number generator, the seed will instead be set to '1'.");
+				value = 1;
+			}
+			
+			_seed = value;
+			_currentSeed = value;
+		}
+		
+		/**
+		 * The current "state" of the original seed. This value changes each time the 'generate()' method is called.
+		 */
+		public function get currentSeed():uint 
+		{
+			return _currentSeed;
+		}
+		
+		/**
+		 * Resets the current "state" of the seed (represented by the 'currentSeed' value) to the original 'seed' value.
+		 */
+		public function resetSeed():void
+		{
+			_currentSeed = seed;
+		}
+		
+		/**
+		 * Picks a new random seed. Note that the seed is chosen by AS3's time-based random generator, and (obviously) not a seeded pseudo-random number generator.
+		 */
+		public function randomizeSeed():void
+		{
+			var newSeed:uint = 0;
+			while (newSeed == 0)
+			{
+				// Odds are 1:2^31, but this might return 0!!
+				newSeed = uint(Math.random() * MODULUS);
+			}
+			this.seed = newSeed;
+		}
+		
+		
+		/**
+		 * Constants used in the pseudorandom number generation equation.
+		 * These are the constants suggested by the revised MINSTD pseudorandom number generator, and they use the full range of possible integer values.
+		 * 
+		 * @see 	http://en.wikipedia.org/wiki/Linear_congruential_generator
+		 * @see 	Stephen K. Park and Keith W. Miller and Paul K. Stockmeyer (1988). "Technical Correspondence". Communications of the ACM 36 (7): 105–110.
+		 */
+		protected const MULTIPLIER:int = 48271;
+		protected const MODULUS:int = 2147483647; // 0x7FFFFFFF (31 bit integer)
+		
+		/**
+		 * Internal method to quickly generate a pseudorandom number. Used only by other functions of this class.
+		 * Also updates the current seed, which will then be used to generate the next pseudorandom number.
+		 * 
+		 * @return	A new pseudorandom number between 0 inclusive and 1 exclusive.
+		 */
+		protected function generate():Number
+		{
+			_currentSeed = ((_currentSeed * MULTIPLIER) % MODULUS);
+			return (_currentSeed / MODULUS);
+		}
+		
+		
+	}
+}

--- a/src/flixel/util/FlxU.as
+++ b/src/flixel/util/FlxU.as
@@ -115,71 +115,6 @@ package flixel.util
 		}
 		
 		/**
-		 * Generates a random number based on the seed provided.
-		 * 
-		 * @param	Seed	A number between 0 and 1, used to generate a predictable random number (very optional).
-		 * 
-		 * @return	A <code>Number</code> between 0 and 1.
-		 */
-		static public function srand(Seed:Number):Number
-		{
-			return ((69621 * int(Seed * 0x7FFFFFFF)) % 0x7FFFFFFF) / 0x7FFFFFFF;
-		}
-		
-		/**
-		 * Shuffles the entries in an array into a new random order.
-		 * <code>FlxG.shuffle()</code> is deterministic and safe for use with replays/recordings.
-		 * HOWEVER, <code>FlxU.shuffle()</code> is NOT deterministic and unsafe for use with replays/recordings.
-		 * 
-		 * @param	A				A Flash <code>Array</code> object containing...stuff.
-		 * @param	HowManyTimes	How many swaps to perform during the shuffle operation.  Good rule of thumb is 2-4 times as many objects are in the list.
-		 * 
-		 * @return	The same Flash <code>Array</code> object that you passed in in the first place.
-		 */
-		static public function shuffle(Objects:Array,HowManyTimes:uint):Array
-		{
-			var i:uint = 0;
-			var index1:uint;
-			var index2:uint;
-			var object:Object;
-			while(i < HowManyTimes)
-			{
-				index1 = Math.random()*Objects.length;
-				index2 = Math.random()*Objects.length;
-				object = Objects[index2];
-				Objects[index2] = Objects[index1];
-				Objects[index1] = object;
-				i++;
-			}
-			return Objects;
-		}
-		
-		/**
-		 * Fetch a random entry from the given array.
-		 * Will return null if random selection is missing, or array has no entries.
-		 * <code>FlxG.getRandom()</code> is deterministic and safe for use with replays/recordings.
-		 * HOWEVER, <code>FlxU.getRandom()</code> is NOT deterministic and unsafe for use with replays/recordings.
-		 * 
-		 * @param	Objects		A Flash array of objects.
-		 * @param	StartIndex	Optional offset off the front of the array. Default value is 0, or the beginning of the array.
-		 * @param	Length		Optional restriction on the number of values you want to randomly select from.
-		 * 
-		 * @return	The random object that was selected.
-		 */
-		static public function getRandom(Objects:Array,StartIndex:uint=0,Length:uint=0):Object
-		{
-			if(Objects != null)
-			{
-				var l:uint = Length;
-				if((l == 0) || (l > Objects.length - StartIndex))
-					l = Objects.length - StartIndex;
-				if(l > 0)
-					return Objects[StartIndex + uint(Math.random()*l)];
-			}
-			return null;
-		}
-		
-		/**
 		 * Just grabs the current "ticks" or time in milliseconds that has passed since Flash Player started up.
 		 * Useful for finding out how long it takes to execute specific blocks of code.
 		 * 
@@ -619,5 +554,83 @@ package flixel.util
 			var dy:Number = Point1.y - Point2.y;
 			return Math.sqrt(dx * dx + dy * dy);
 		}
+		
+		
+		/*     --- Deprecated members in Flixel v2.57 ---     */
+		/*  To be removed after developers have had time to adjust to the new changes. */
+		
+		/**
+		 * Generates a random number based on the seed provided.
+		 * 
+		 * @param	Seed	A number between 0 and 1, used to generate a predictable random number (very optional).
+		 * 
+		 * @return	A <code>Number</code> between 0 and 1.
+		 * 
+		 * @deprecated This property is deprecated. Use the <code>FlxRandom</code> class instead.
+		 */
+		static public function srand(Seed:Number):Number
+		{
+			FlxG.warnDeprecated('FlxU.srand()', 'FlxRandom');
+			// I'll just keep using the old deprecated method for now. No use using FlxRandom since the RNG is slightly different.
+			return ((69621 * int(Seed * 0x7FFFFFFF)) % 0x7FFFFFFF) / 0x7FFFFFFF;
+		}
+		
+		/**
+		 * Shuffles the entries in an array into a new random order.
+		 * NOT deterministic and unsafe for use with replays/recordings.
+		 * 
+		 * @param	Objects			A Flash <code>Array</code> object containing...stuff.
+		 * @param	HowManyTimes	How many swaps to perform during the shuffle operation.  Good rule of thumb is 2-4 times as many objects are in the list.
+		 * 
+		 * @return	The same Flash <code>Array</code> object that you passed in in the first place.
+		 * 
+		 * @deprecated This property is deprecated. Use the <code>shuffle()</code> method of the <code>FlxRandom</code> class instead.
+		 */
+		static public function shuffle(Objects:Array,HowManyTimes:uint):Array
+		{
+			FlxG.warnDeprecated('FlxU.shuffle()', 'FlxRandom#shuffle()');
+			var i:uint = 0;
+			var index1:uint;
+			var index2:uint;
+			var object:Object;
+			while(i < HowManyTimes)
+			{
+				index1 = Math.random()*Objects.length;
+				index2 = Math.random()*Objects.length;
+				object = Objects[index2];
+				Objects[index2] = Objects[index1];
+				Objects[index1] = object;
+				i++;
+			}
+			return Objects;
+		}
+		
+		/**
+		 * Fetch a random entry from the given array.
+		 * Will return null if random selection is missing, or array has no entries.
+		 * NOT deterministic and unsafe for use with replays/recordings.
+		 * 
+		 * @param	Objects		A Flash array of objects.
+		 * @param	StartIndex	Optional offset off the front of the array. Default value is 0, or the beginning of the array.
+		 * @param	Length		Optional restriction on the number of values you want to randomly select from.
+		 * 
+		 * @return	The random object that was selected.
+		 * 
+		 * @deprecated This property is deprecated. Use the <code>item()</code> method of the <code>FlxRandom</code> class instead.
+		 */
+		static public function getRandom(Objects:Array,StartIndex:uint=0,Length:uint=0):Object
+		{
+			FlxG.warnDeprecated('FlxU.getRandom()', 'FlxRandom#item()');
+			if(Objects != null)
+			{
+				var l:uint = Length;
+				if((l == 0) || (l > Objects.length - StartIndex))
+					l = Objects.length - StartIndex;
+				if(l > 0)
+					return Objects[StartIndex + uint(Math.random()*l)];
+			}
+			return null;
+		}
+		
 	}
 }


### PR DESCRIPTION
The new `FlxRandom` class contains the following methods:

``` as3
float(min:Number = 0,max:Number = 1):Number
boolean(chance:Number = 0.5):Boolean
sign(chance:Number = 0.5):int // Returns either 1 or -1
bit(chance:Number = 0.5):int // Returns either 1 or 0
integer(min:Number, max:Number = NaN):int
item(array:Array, startIndex:uint = 0, length:uint = 0):* // Pick a random item out of an array between 'startIndex' and 'length'
shuffle(array:Array, modifyArray:Boolean = true):Array
```

Any methods or properties that are replaced by this method get their own little `@deprecated` tag in the ASDoc, as well as a warning written to the console every time they try to use that method.
