### PR TITLE
Reorganize `FlxU`

### DIFF
--- a/src/flixel/FlxCamera.as
+++ b/src/flixel/FlxCamera.as
@@ -7,7 +7,7 @@ package flixel
 	import flash.geom.Point;
 	import flash.geom.Rectangle;
 	
-	import flixel.util.FlxU;
+	import flixel.util.FlxMath;
 	import flixel.util.FlxPoint;
 	import flixel.util.FlxRect;
 
@@ -308,8 +308,8 @@ package flixel
 					
 					if ((target is FlxSprite) && (FlxSprite(target).isSimpleRender()))
 					{
-						targetX = FlxU.floor(targetX);
-						targetY = FlxU.floor(targetY);
+						targetX = FlxMath.floor(targetX);
+						targetY = FlxMath.floor(targetY);
 					}
 					
 					edge = targetX - deadzone.x;
@@ -407,7 +407,7 @@ package flixel
 				case STYLE_TOPDOWN:
 				case STYLE_TOPDOWN_TIGHT:
 					var tdTightness:Number = (Style == STYLE_TOPDOWN_TIGHT) ? 8 : 4;
-					var tdHelper:Number = FlxU.max(width,height)/tdTightness;
+					var tdHelper:Number = FlxMath.max(width,height)/tdTightness;
 					deadzone = new FlxRect((width-tdHelper)/2,(height-tdHelper)/2,tdHelper,tdHelper);
 					break;
 				case STYLE_LOCKON:

--- a/src/flixel/FlxG.as
+++ b/src/flixel/FlxG.as
@@ -1,5 +1,6 @@
 package flixel
 {
+	import flash.utils.getTimer;
 	import flixel.util.FlxRandom;
 	import flixel.util.FlxU;
 	import flixel.system.FlxSound;
@@ -340,6 +341,15 @@ package flixel
 			_game._maxAccumulation = 2000/_game._flashFramerate - 1;
 			if(_game._maxAccumulation < _game._step)
 				_game._maxAccumulation = _game._step;
+		}
+		
+		/**
+		 * Just grabs the current "ticks" or time in milliseconds that has passed since Flash Player started up.
+		 * Useful for finding out how long it takes to execute specific blocks of code.
+		 */
+		static public function getTicks():uint
+		{
+			return getTimer();
 		}
 		
 		/**

--- a/src/flixel/FlxGame.as
+++ b/src/flixel/FlxGame.as
@@ -1,8 +1,5 @@
 package flixel
 {
-	import flixel.plugin.timer.FlxTimer;
-	import flixel.util.FlxU;
-	import flixel.system.FlxSave;
 	import flash.display.Bitmap;
 	import flash.display.BitmapData;
 	import flash.display.Graphics;
@@ -17,8 +14,11 @@ package flixel
 	import flash.ui.Mouse;
 	import flash.utils.getTimer;
 	
-	import flixel.plugin.timer.TimerManager;
 	import flixel.plugin.replay.FlxReplay;
+	import flixel.plugin.timer.TimerManager;
+	import flixel.plugin.timer.FlxTimer;
+	import flixel.util.FlxMath;
+	import flixel.system.FlxSave;
 	import flixel.system.debug.FlxDebugger;
 
 	/**
@@ -778,7 +778,7 @@ package flixel
 			//draw white arrow
 			var halfWidth:uint = screenWidth/2;
 			var halfHeight:uint = screenHeight/2;
-			var helper:uint = FlxU.min(halfWidth,halfHeight)/3;
+			var helper:uint = FlxMath.min(halfWidth,halfHeight)/3;
 			gfx.moveTo(halfWidth-helper,halfHeight-helper);
 			gfx.beginFill(0xffffff,0.65);
 			gfx.lineTo(halfWidth+helper,halfHeight);

--- a/src/flixel/FlxObject.as
+++ b/src/flixel/FlxObject.as
@@ -4,6 +4,7 @@ package flixel
 	
 	import flixel.tile.FlxTilemap;
 	import flixel.util.FlxU;
+	import flixel.util.FlxMath;
 	import flixel.util.FlxPath;
 	import flixel.util.FlxRect;
 	import flixel.util.FlxPoint;
@@ -486,7 +487,7 @@ package flixel
 			}
 			
 			path = Path;
-			pathSpeed = FlxU.abs(Speed);
+			pathSpeed = FlxMath.abs(Speed);
 			_pathMode = Mode;
 			_pathRotate = AutoRotate;
 			

--- a/src/flixel/FlxObject.as
+++ b/src/flixel/FlxObject.as
@@ -660,8 +660,8 @@ package flixel
 				}
 				else
 				{
-					pathAngle = FlxU.getAngle(_point,node);
-					FlxU.rotatePoint(0,pathSpeed,0,0,pathAngle,velocity);
+					pathAngle = FlxPoint.angleBetween(_point,node);
+					FlxPoint.rotate(0,pathSpeed,0,0,pathAngle,velocity);
 				}
 				
 				//then set object rotation if necessary

--- a/src/flixel/FlxObject.as
+++ b/src/flixel/FlxObject.as
@@ -3,7 +3,6 @@ package flixel
 	import flash.display.Graphics;
 	
 	import flixel.tile.FlxTilemap;
-	import flixel.util.FlxU;
 	import flixel.util.FlxMath;
 	import flixel.util.FlxPath;
 	import flixel.util.FlxRect;
@@ -384,18 +383,18 @@ package flixel
 			var delta:Number;
 			var velocityDelta:Number;
 
-			velocityDelta = (FlxU.computeVelocity(angularVelocity,angularAcceleration,angularDrag,maxAngular) - angularVelocity)/2;
+			velocityDelta = (FlxMath.computeVelocity(FlxG.elapsed, angularVelocity,angularAcceleration,angularDrag,maxAngular) - angularVelocity)/2;
 			angularVelocity += velocityDelta; 
 			angle += angularVelocity*FlxG.elapsed;
 			angularVelocity += velocityDelta;
 			
-			velocityDelta = (FlxU.computeVelocity(velocity.x,acceleration.x,drag.x,maxVelocity.x) - velocity.x)/2;
+			velocityDelta = (FlxMath.computeVelocity(FlxG.elapsed, velocity.x,acceleration.x,drag.x,maxVelocity.x) - velocity.x)/2;
 			velocity.x += velocityDelta;
 			delta = velocity.x*FlxG.elapsed;
 			velocity.x += velocityDelta;
 			x += delta;
 			
-			velocityDelta = (FlxU.computeVelocity(velocity.y,acceleration.y,drag.y,maxVelocity.y) - velocity.y)/2;
+			velocityDelta = (FlxMath.computeVelocity(FlxG.elapsed, velocity.y,acceleration.y,drag.y,maxVelocity.y) - velocity.y)/2;
 			velocity.y += velocityDelta;
 			delta = velocity.y*FlxG.elapsed;
 			velocity.y += velocityDelta;

--- a/src/flixel/FlxSprite.as
+++ b/src/flixel/FlxSprite.as
@@ -8,7 +8,7 @@ package flixel
 	import flash.geom.Rectangle;
 	
 	import flixel.animation.FlxAnimation;
-	import flixel.util.FlxU;
+	import flixel.util.FlxMath;
 	import flixel.util.FlxPoint;
 	
 	/**
@@ -332,7 +332,7 @@ package flixel
 				max = brush.height;
 			if(AutoBuffer)
 				max *= 1.5;
-			var columns:uint = FlxU.ceil(Rotations/rows);
+			var columns:uint = FlxMath.ceil(Rotations/rows);
 			width = max*columns;
 			height = max*rows;
 			var key:String = String(Graphic) + ":" + Frame + ":" + width + "x" + height;
@@ -423,8 +423,8 @@ package flixel
 			_numFrames = 0;
 			
 			var widthHelper:uint = _flipped?_flipped:_pixels.width;
-			var maxFramesX:uint = FlxU.floor(widthHelper / frameWidth);
-			var maxFramesY:uint = FlxU.floor(_pixels.height / frameHeight);
+			var maxFramesX:uint = FlxMath.floor(widthHelper / frameWidth);
+			var maxFramesY:uint = FlxMath.floor(_pixels.height / frameHeight);
 			_maxFrames = maxFramesX * maxFramesY;
 		}
 		

--- a/src/flixel/system/FlxSound.as
+++ b/src/flixel/system/FlxSound.as
@@ -1,7 +1,6 @@
 package flixel.system
 {
 	import flixel.FlxG;
-	import flixel.util.FlxU;
 	import flixel.util.FlxPoint;
 	import flixel.util.FlxTween;
 	import flixel.FlxObject;

--- a/src/flixel/system/FlxSound.as
+++ b/src/flixel/system/FlxSound.as
@@ -195,7 +195,7 @@ package flixel.system
 			//Distance-based volume control
 			if(_target != null)
 			{
-				radialMultiplier = FlxU.getDistance(new FlxPoint(_target.x,_target.y),new FlxPoint(x,y))/_radius;
+				radialMultiplier = FlxPoint.distance(new FlxPoint(_target.x,_target.y),new FlxPoint(x,y))/_radius;
 				if(radialMultiplier < 0) radialMultiplier = 0;
 				if(radialMultiplier > 1) radialMultiplier = 1;
 				

--- a/src/flixel/system/debug/FlxWindow.as
+++ b/src/flixel/system/debug/FlxWindow.as
@@ -10,7 +10,7 @@ package flixel.system.debug
 	import flash.text.TextField;
 	import flash.text.TextFormat;
 	
-	import flixel.util.FlxU;
+	import flixel.util.FlxMath;
 	
 	/**
 	 * A generic, Flash-based window class, created for use in <code>FlxDebugger</code>.
@@ -286,8 +286,8 @@ package flixel.system.debug
 		{
 			if(_bounds != null)
 			{
-				x = FlxU.bound(x,_bounds.left,_bounds.right-_width);
-				y = FlxU.bound(y,_bounds.top,_bounds.bottom-_height);
+				x = FlxMath.clamp(x,_bounds.left,_bounds.right-_width);
+				y = FlxMath.clamp(y,_bounds.top,_bounds.bottom-_height);
 			}
 		}
 		
@@ -296,8 +296,8 @@ package flixel.system.debug
 		 */
 		protected function updateSize():void
 		{
-			_width = FlxU.bound(_width,minSize.x,maxSize.x);
-			_height = FlxU.bound(_height,minSize.y,maxSize.y);
+			_width = FlxMath.clamp(_width,minSize.x,maxSize.x);
+			_height = FlxMath.clamp(_height,minSize.y,maxSize.y);
 			
 			_header.scaleX = _width;
 			_background.scaleX = _width;

--- a/src/flixel/tile/FlxTilemap.as
+++ b/src/flixel/tile/FlxTilemap.as
@@ -1,22 +1,21 @@
 package flixel.tile
 {
-	import flixel.util.FlxRect;
 	import flixel.FlxBasic;
-	import flixel.FlxGroup;
-	import flixel.util.FlxU;
-	import flixel.util.FlxPath;
-	import flixel.util.FlxPoint;
 	import flixel.FlxCamera;
 	import flixel.FlxG;
+	import flixel.FlxGroup;
+	import flixel.FlxObject;
+	
+	import flixel.util.FlxMath;
+	import flixel.util.FlxPath;
+	import flixel.util.FlxPoint;
+	import flixel.util.FlxRect;
+	
 	import flash.display.BitmapData;
 	import flash.display.Graphics;
 	import flash.geom.Matrix;
 	import flash.geom.Point;
 	import flash.geom.Rectangle;
-
-	import flixel.FlxObject;
-	import flixel.tile.FlxTile;
-	import flixel.tile.FlxTilemapBuffer;
 
 	/**
 	 * This is a traditional tilemap display and collision class.
@@ -962,10 +961,10 @@ package flixel.tile
 			}
 			
 			//Figure out what tiles we need to check against
-			var selectionX:int = FlxU.floor((TargetObject.x - X)/_tileWidth);
-			var selectionY:int = FlxU.floor((TargetObject.y - Y)/_tileHeight);
-			var selectionWidth:uint = selectionX + (FlxU.ceil(TargetObject.width/_tileWidth)) + 1;
-			var selectionHeight:uint = selectionY + FlxU.ceil(TargetObject.height/_tileHeight) + 1;
+			var selectionX:int = FlxMath.floor((TargetObject.x - X)/_tileWidth);
+			var selectionY:int = FlxMath.floor((TargetObject.y - Y)/_tileHeight);
+			var selectionWidth:uint = selectionX + (FlxMath.ceil(TargetObject.width/_tileWidth)) + 1;
+			var selectionHeight:uint = selectionY + FlxMath.ceil(TargetObject.height/_tileHeight) + 1;
 			
 			//Then bound these coordinates by the map edges
 			if(selectionX < 0)

--- a/src/flixel/tile/FlxTilemapBuffer.as
+++ b/src/flixel/tile/FlxTilemapBuffer.as
@@ -6,7 +6,7 @@ package flixel.tile
 	
 	import flixel.FlxG;
 	import flixel.FlxCamera;
-	import flixel.util.FlxU;
+	import flixel.util.FlxMath;
 
 	/**
 	 * A helper object to keep tilemap drawing performance decent across the new multi-camera system.
@@ -62,10 +62,10 @@ package flixel.tile
 			if(Camera == null)
 				Camera = FlxG.camera;
 
-			columns = FlxU.ceil(Camera.width/TileWidth)+1;
+			columns = FlxMath.ceil(Camera.width/TileWidth)+1;
 			if(columns > WidthInTiles)
 				columns = WidthInTiles;
-			rows = FlxU.ceil(Camera.height/TileHeight)+1;
+			rows = FlxMath.ceil(Camera.height/TileHeight)+1;
 			if(rows > HeightInTiles)
 				rows = HeightInTiles;
 			

--- a/src/flixel/util/FlxMath.as
+++ b/src/flixel/util/FlxMath.as
@@ -97,5 +97,39 @@ package flixel.util
 			var lowerBound:Number = (Value<Min)?Min:Value;
 			return (lowerBound>Max)?Max:lowerBound;
 		}
+		
+		
+		/**
+		 * A tween-like function that takes a starting velocity
+		 * and some other factors and returns an altered velocity.
+		 * 
+		 * @param	TimeElapsed		The amount of time in seconds that passed since last frame.
+		 * @param	Velocity		Any component of velocity (e.g. 20).
+		 * @param	Acceleration	Rate at which the velocity is changing.
+		 * @param	Drag			Really kind of a deceleration, this is how much the velocity changes if Acceleration is not set.
+		 * @param	Max				An optional absolute value cap for the velocity.
+		 * 
+		 * @return	The altered Velocity value.
+		 */
+		static public function computeVelocity(TimeElapsed:Number, Velocity:Number, Acceleration:Number=0, Drag:Number=0, Max:Number=NaN):Number
+		{
+			if(Acceleration != 0)
+				Velocity += Acceleration*TimeElapsed;
+			else if(Drag != 0)
+			{
+				var drag:Number = Drag*TimeElapsed;
+				if(Velocity - drag > 0)
+					Velocity = Velocity - drag;
+				else if(Velocity + drag < 0)
+					Velocity += drag;
+				else
+					Velocity = 0;
+			}
+			if((Velocity != 0) && (!isNaN(Max)))
+			{
+				Velocity = FlxMath.clamp(Velocity, -Max, Max);
+			}
+			return Velocity;
+		}
 	}
 }

--- a/src/flixel/util/FlxMath.as
+++ b/src/flixel/util/FlxMath.as
@@ -1,0 +1,101 @@
+package flixel.util
+{
+	/**
+	 * Contains various Math functions and helpers, not dependent on any target platform.
+	 */
+	public class FlxMath
+	{
+		/**
+		 * Calculate the absolute value of a number.
+		 * 
+		 * @param	Value	Any number.
+		 * 
+		 * @return	The absolute value of that number.
+		 */
+		static public function abs(Value:Number):Number
+		{
+			return (Value>0)?Value:-Value;
+		}
+		
+		/**
+		 * Round down to the next whole number. E.g. floor(1.7) == 1, and floor(-2.7) == -2.
+		 * 
+		 * @param	Value	Any number.
+		 * 
+		 * @return	The rounded value of that number.
+		 */
+		static public function floor(Value:Number):Number
+		{
+			var number:Number = int(Value);
+			return (Value>0)?(number):((number!=Value)?(number-1):(number));
+		}
+		
+		/**
+		 * Round up to the next whole number.  E.g. ceil(1.3) == 2, and ceil(-2.3) == -3.
+		 * 
+		 * @param	Value	Any number.
+		 * 
+		 * @return	The rounded value of that number.
+		 */
+		static public function ceil(Value:Number):Number
+		{
+			var number:Number = int(Value);
+			return (Value>0)?((number!=Value)?(number+1):(number)):(number);
+		}
+		
+		/**
+		 * Round to the closest whole number. E.g. round(1.7) == 2, and round(-2.3) == -2.
+		 * 
+		 * @param	Value	Any number.
+		 * 
+		 * @return	The rounded value of that number.
+		 */
+		static public function round(Value:Number):Number
+		{
+			return int(Value+((Value>0)?0.5:-0.5));
+		}
+		
+		/**
+		 * Figure out which number is smaller.
+		 * 
+		 * @param	Number1		Any number.
+		 * @param	Number2		Any number.
+		 * 
+		 * @return	The smaller of the two numbers.
+		 */
+		static public function min(Number1:Number,Number2:Number):Number
+		{
+			return (Number1 <= Number2)?Number1:Number2;
+		}
+		
+		/**
+		 * Figure out which number is larger.
+		 * 
+		 * @param	Number1		Any number.
+		 * @param	Number2		Any number.
+		 * 
+		 * @return	The larger of the two numbers.
+		 */
+		static public function max(Number1:Number,Number2:Number):Number
+		{
+			return (Number1 >= Number2)?Number1:Number2;
+		}
+		
+		/**
+		 * Clamp (bound) a number by a minimum and maximum.
+		 * Ensures that this number is no smaller than the minimum,
+		 * and no larger than the maximum.
+		 * 
+		 * @param	Value	Any number.
+		 * @param	Min		Any number.
+		 * @param	Max		Any number.
+		 * 
+		 * @return	The clamped (bounded) value of the number.
+		 */
+		static public function clamp(Value:Number,Min:Number,Max:Number):Number
+		{
+			var lowerBound:Number = (Value<Min)?Min:Value;
+			return (lowerBound>Max)?Max:lowerBound;
+		}
+	}
+}

--- a/src/flixel/util/FlxPoint.as
+++ b/src/flixel/util/FlxPoint.as
@@ -9,6 +9,125 @@ package flixel.util
 	 */
 	public class FlxPoint
 	{
+		
+		/*     --- Static helper methods ---     */
+		
+		/**
+		 * Calculates the angle between two points.  0 degrees points straight up.
+		 * 
+		 * @param	point1		The X coordinate of the point.
+		 * @param	point2		The Y coordinate of the point.
+		 * 
+		 * @return	The angle in degrees, between -180 and 180.
+		 */
+		static public function angleBetween(point1:FlxPoint, point2:FlxPoint):Number
+		{
+			var x:Number = point2.x - point1.x;
+			var y:Number = point2.y - point1.y;
+			if((x == 0) && (y == 0))
+				return 0;
+			var c1:Number = 3.14159265 * 0.25;
+			var c2:Number = 3 * c1;
+			var ay:Number = (y < 0)?-y:y;
+			var angle:Number = 0;
+			if (x >= 0)
+				angle = c1 - c1 * ((x - ay) / (x + ay));
+			else
+				angle = c2 - c1 * ((x + ay) / (ay - x));
+			angle = ((y < 0)?-angle:angle)*57.2957796;
+			if(angle > 90)
+				angle = angle - 270;
+			else
+				angle += 90;
+			return angle;
+		}
+		
+		/**
+		 * Calculate the distance between two points.
+		 * 
+		 * @param point1	A <code>FlxPoint</code> object referring to the first location.
+		 * @param point2	A <code>FlxPoint</code> object referring to the second location.
+		 * 
+		 * @return	The distance between the two points as a floating point <code>Number</code> object.
+		 */
+		static public function distance(point1:FlxPoint, point2:FlxPoint):Number
+		{
+			var dx:Number = point1.x - point2.x;
+			var dy:Number = point1.y - point2.y;
+			return Math.sqrt(dx * dx + dy * dy);
+		}
+		
+		/**
+		 * Rotates a point in 2D space around another point by the given angle.
+		 * 
+		 * @param	X		The X coordinate of the point you want to rotate.
+		 * @param	Y		The Y coordinate of the point you want to rotate.
+		 * @param	pivotX	The X coordinate of the point you want to rotate around.
+		 * @param	pivotY	The Y coordinate of the point you want to rotate around.
+		 * @param	angle	Rotate the point by this many degrees.
+		 * @param	point	Optional <code>FlxPoint</code> to store the results in.
+		 * 
+		 * @return	A <code>FlxPoint</code> containing the coordinates of the rotated point.
+		 */
+		static public function rotate(X:Number, Y:Number, pivotX:Number, pivotY:Number, angle:Number, point:FlxPoint=null):FlxPoint
+		{
+			var sin:Number = 0;
+			var cos:Number = 0;
+			var radians:Number = angle * -0.017453293;
+			while (radians < -3.14159265)
+				radians += 6.28318531;
+			while (radians >  3.14159265)
+				radians = radians - 6.28318531;
+			
+			if (radians < 0)
+			{
+				sin = 1.27323954 * radians + .405284735 * radians * radians;
+				if (sin < 0)
+					sin = .225 * (sin *-sin - sin) + sin;
+				else
+					sin = .225 * (sin * sin - sin) + sin;
+			}
+			else
+			{
+				sin = 1.27323954 * radians - 0.405284735 * radians * radians;
+				if (sin < 0)
+					sin = .225 * (sin *-sin - sin) + sin;
+				else
+					sin = .225 * (sin * sin - sin) + sin;
+			}
+			
+			radians += 1.57079632;
+			if (radians >  3.14159265)
+				radians = radians - 6.28318531;
+			if (radians < 0)
+			{
+				cos = 1.27323954 * radians + 0.405284735 * radians * radians;
+				if (cos < 0)
+					cos = .225 * (cos *-cos - cos) + cos;
+				else
+					cos = .225 * (cos * cos - cos) + cos;
+			}
+			else
+			{
+				cos = 1.27323954 * radians - 0.405284735 * radians * radians;
+				if (cos < 0)
+					cos = .225 * (cos *-cos - cos) + cos;
+				else
+					cos = .225 * (cos * cos - cos) + cos;
+			}
+			
+			var dx:Number = X-pivotX;
+			var dy:Number = pivotY+Y; //Y axis is inverted in flash, normally this would be a subtract operation
+			if(point == null)
+				point = new FlxPoint();
+			point.x = pivotX + cos*dx - sin*dy;
+			point.y = pivotY - sin*dx - cos*dy;
+			return point;
+		}
+		
+		
+		/*     --- Actual instance ---     */
+		
 		/**
 		 * @default 0
 		 */

--- a/src/flixel/util/FlxRandom.as
+++ b/src/flixel/util/FlxRandom.as
@@ -1,7 +1,7 @@
 package flixel.util
 {
 	import flixel.FlxG;
-	import flixel.util.FlxU;
+	import flixel.util.FlxMath;
 	
 	/**
 	 * A class containing a set of functions for random generation.
@@ -188,7 +188,7 @@ package flixel.util
 		{
 			if (isNaN(max)) { max = min; min = 0; }
 			// Need to use floor instead of bit shift to work properly with negative values:
-			return FlxU.floor(float(min, max + 1));
+			return FlxMath.floor(float(min, max + 1));
 		}
 		
 		/**

--- a/src/flixel/util/FlxU.as
+++ b/src/flixel/util/FlxU.as
@@ -300,41 +300,6 @@ package flixel.util
 			return getDefinitionByName(Name) as Class;
 		}
 		
-		/**
-		 * A tween-like function that takes a starting velocity
-		 * and some other factors and returns an altered velocity.
-		 * 
-		 * @param	Velocity		Any component of velocity (e.g. 20).
-		 * @param	Acceleration	Rate at which the velocity is changing.
-		 * @param	Drag			Really kind of a deceleration, this is how much the velocity changes if Acceleration is not set.
-		 * @param	Max				An absolute value cap for the velocity.
-		 * 
-		 * @return	The altered Velocity value.
-		 */
-		static public function computeVelocity(Velocity:Number, Acceleration:Number=0, Drag:Number=0, Max:Number=10000):Number
-		{
-			if(Acceleration != 0)
-				Velocity += Acceleration*FlxG.elapsed;
-			else if(Drag != 0)
-			{
-				var drag:Number = Drag*FlxG.elapsed;
-				if(Velocity - drag > 0)
-					Velocity = Velocity - drag;
-				else if(Velocity + drag < 0)
-					Velocity += drag;
-				else
-					Velocity = 0;
-			}
-			if((Velocity != 0) && (Max != 10000))
-			{
-				if(Velocity > Max)
-					Velocity = Max;
-				else if(Velocity < -Max)
-					Velocity = -Max;
-			}
-			return Velocity;
-		}
-		
 		
 		/*     --- Deprecated members in Flixel v2.57 ---     */
 		/*  To be removed after developers have had time to adjust to the new changes. */
@@ -575,6 +540,28 @@ package flixel.util
 			FlxG.warnDeprecated('FlxU.bound()', 'FlxMath.clamp()');
 			return FlxMath.clamp(Value, Min, Max);
 		}
+		
+		
+		/**
+		 * A tween-like function that takes a starting velocity
+		 * and some other factors and returns an altered velocity.
+		 * 
+		 * @deprecated This property is deprecated. Use <code>FlxMath.clamp()</code> instead.
+		 * 		Note the difference in arguments!
+		 * 
+		 * @param	Velocity		Any component of velocity (e.g. 20).
+		 * @param	Acceleration	Rate at which the velocity is changing.
+		 * @param	Drag			Really kind of a deceleration, this is how much the velocity changes if Acceleration is not set.
+		 * @param	Max				An absolute value cap for the velocity.
+		 * 
+		 * @return	The altered Velocity value.
+		 */
+		static public function computeVelocity(Velocity:Number, Acceleration:Number=0, Drag:Number=0, Max:Number=NaN):Number
+		{
+			FlxG.warnDeprecated('FlxU.computeVelocity()', 'FlxMath.computeVelocity()');
+			return FlxMath.computeVelocity(FlxG.elapsed, Velocity, Acceleration, Drag, Max);
+		}
+		
 		
 		/**
 		 * Just grabs the current "ticks" or time in milliseconds that has passed since Flash Player started up.

--- a/src/flixel/util/FlxU.as
+++ b/src/flixel/util/FlxU.as
@@ -22,99 +22,6 @@ package flixel.util
 		}
 		
 		/**
-		 * Calculate the absolute value of a number.
-		 * 
-		 * @param	Value	Any number.
-		 * 
-		 * @return	The absolute value of that number.
-		 */
-		static public function abs(Value:Number):Number
-		{
-			return (Value>0)?Value:-Value;
-		}
-		
-		/**
-		 * Round down to the next whole number. E.g. floor(1.7) == 1, and floor(-2.7) == -2.
-		 * 
-		 * @param	Value	Any number.
-		 * 
-		 * @return	The rounded value of that number.
-		 */
-		static public function floor(Value:Number):Number
-		{
-			var number:Number = int(Value);
-			return (Value>0)?(number):((number!=Value)?(number-1):(number));
-		}
-		
-		/**
-		 * Round up to the next whole number.  E.g. ceil(1.3) == 2, and ceil(-2.3) == -3.
-		 * 
-		 * @param	Value	Any number.
-		 * 
-		 * @return	The rounded value of that number.
-		 */
-		static public function ceil(Value:Number):Number
-		{
-			var number:Number = int(Value);
-			return (Value>0)?((number!=Value)?(number+1):(number)):(number);
-		}
-		
-		/**
-		 * Round to the closest whole number. E.g. round(1.7) == 2, and round(-2.3) == -2.
-		 * 
-		 * @param	Value	Any number.
-		 * 
-		 * @return	The rounded value of that number.
-		 */
-		static public function round(Value:Number):Number
-		{
-			return int(Value+((Value>0)?0.5:-0.5));
-		}
-		
-		/**
-		 * Figure out which number is smaller.
-		 * 
-		 * @param	Number1		Any number.
-		 * @param	Number2		Any number.
-		 * 
-		 * @return	The smaller of the two numbers.
-		 */
-		static public function min(Number1:Number,Number2:Number):Number
-		{
-			return (Number1 <= Number2)?Number1:Number2;
-		}
-		
-		/**
-		 * Figure out which number is larger.
-		 * 
-		 * @param	Number1		Any number.
-		 * @param	Number2		Any number.
-		 * 
-		 * @return	The larger of the two numbers.
-		 */
-		static public function max(Number1:Number,Number2:Number):Number
-		{
-			return (Number1 >= Number2)?Number1:Number2;
-		}
-		
-		/**
-		 * Bound a number by a minimum and maximum.
-		 * Ensures that this number is no smaller than the minimum,
-		 * and no larger than the maximum.
-		 * 
-		 * @param	Value	Any number.
-		 * @param	Min		Any number.
-		 * @param	Max		Any number.
-		 * 
-		 * @return	The bounded value of the number.
-		 */
-		static public function bound(Value:Number,Min:Number,Max:Number):Number
-		{
-			var lowerBound:Number = (Value<Min)?Min:Value;
-			return (lowerBound>Max)?Max:lowerBound;
-		}
-		
-		/**
 		 * Just grabs the current "ticks" or time in milliseconds that has passed since Flash Player started up.
 		 * Useful for finding out how long it takes to execute specific blocks of code.
 		 * 
@@ -570,5 +477,115 @@ package flixel.util
 			return FlxPoint.distance(point1, point2);
 		}
 		
+		/**
+		 * Calculate the absolute value of a number.
+		 * 
+		 * @deprecated This property is deprecated. Use <code>FlxMath.abs()</code> instead.
+		 * 
+		 * @param	Value	Any number.
+		 * 
+		 * @return	The absolute value of that number.
+		 */
+		static public function abs(Value:Number):Number
+		{
+			FlxG.warnDeprecated('FlxU.abs()', 'FlxMath.abs()');
+			return FlxMath.abs(Value);
+		}
+		
+		/**
+		 * Round down to the next whole number. E.g. floor(1.7) == 1, and floor(-2.7) == -2.
+		 * 
+		 * @deprecated This property is deprecated. Use <code>FlxMath.floor()</code> instead.
+		 * 
+		 * @param	Value	Any number.
+		 * 
+		 * @return	The rounded value of that number.
+		 */
+		static public function floor(Value:Number):Number
+		{
+			FlxG.warnDeprecated('FlxU.floor()', 'FlxMath.floor()');
+			return FlxMath.floor(Value);
+		}
+		
+		/**
+		 * Round up to the next whole number.  E.g. ceil(1.3) == 2, and ceil(-2.3) == -3.
+		 * 
+		 * @deprecated This property is deprecated. Use <code>FlxMath.ceil()</code> instead.
+		 * 
+		 * @param	Value	Any number.
+		 * 
+		 * @return	The rounded value of that number.
+		 */
+		static public function ceil(Value:Number):Number
+		{
+			FlxG.warnDeprecated('FlxU.ceil()', 'FlxMath.ceil()');
+			return FlxMath.ceil(Value);
+		}
+		
+		/**
+		 * Round to the closest whole number. E.g. round(1.7) == 2, and round(-2.3) == -2.
+		 * 
+		 * @deprecated This property is deprecated. Use <code>FlxMath.round()</code> instead.
+		 * 
+		 * @param	Value	Any number.
+		 * 
+		 * @return	The rounded value of that number.
+		 */
+		static public function round(Value:Number):Number
+		{
+			FlxG.warnDeprecated('FlxU.round()', 'FlxMath.round()');
+			return FlxU.round(Value);
+		}
+		
+		/**
+		 * Figure out which number is smaller.
+		 * 
+		 * @deprecated This property is deprecated. Use <code>FlxMath.min()</code> instead.
+		 * 
+		 * @param	Number1		Any number.
+		 * @param	Number2		Any number.
+		 * 
+		 * @return	The smaller of the two numbers.
+		 */
+		static public function min(Number1:Number,Number2:Number):Number
+		{
+			FlxG.warnDeprecated('FlxU.min()', 'FlxMath.min()');
+			return FlxMath.min(Number1, Number2);
+		}
+		
+		/**
+		 * Figure out which number is larger.
+		 * 
+		 * @deprecated This property is deprecated. Use <code>FlxMath.max()</code> instead.
+		 * 
+		 * @param	Number1		Any number.
+		 * @param	Number2		Any number.
+		 * 
+		 * @return	The larger of the two numbers.
+		 */
+		static public function max(Number1:Number,Number2:Number):Number
+		{
+			FlxG.warnDeprecated('FlxU.max()', 'FlxMath.max()');
+			return FlxMath.max(Number1, Number2);
+		}
+		
+		/**
+		 * Bound a number by a minimum and maximum.
+		 * Ensures that this number is no smaller than the minimum,
+		 * and no larger than the maximum.
+		 * 
+		 * @deprecated This property is deprecated. Use <code>FlxMath.clamp()</code> instead.
+		 * 
+		 * @param	Value	Any number.
+		 * @param	Min		Any number.
+		 * @param	Max		Any number.
+		 * 
+		 * @return	The bounded value of the number.
+		 */
+		static public function bound(Value:Number,Min:Number,Max:Number):Number
+		{
+			FlxG.warnDeprecated('FlxU.bound()', 'FlxMath.clamp()');
+			return FlxMath.clamp(Value, Min, Max);
+		}
 	}
 }

--- a/src/flixel/util/FlxU.as
+++ b/src/flixel/util/FlxU.as
@@ -4,7 +4,6 @@ package flixel.util
 	import flash.net.navigateToURL;
 	import flash.utils.getDefinitionByName;
 	import flash.utils.getQualifiedClassName;
-	import flash.utils.getTimer;
 	
 	import flixel.FlxG;
 	
@@ -19,17 +18,6 @@ package flixel.util
 		static public function openURL(URL:String):void
 		{
 			navigateToURL(new URLRequest(URL), "_blank");
-		}
-		
-		/**
-		 * Just grabs the current "ticks" or time in milliseconds that has passed since Flash Player started up.
-		 * Useful for finding out how long it takes to execute specific blocks of code.
-		 * 
-		 * @return	A <code>uint</code> to be passed to <code>FlxU.endProfile()</code>.
-		 */
-		static public function getTicks():uint
-		{
-			return getTimer();
 		}
 		
 		/**
@@ -586,6 +574,18 @@ package flixel.util
 		{
 			FlxG.warnDeprecated('FlxU.bound()', 'FlxMath.clamp()');
 			return FlxMath.clamp(Value, Min, Max);
+		}
+		
+		/**
+		 * Just grabs the current "ticks" or time in milliseconds that has passed since Flash Player started up.
+		 * Useful for finding out how long it takes to execute specific blocks of code.
+		 * 
+		 * @deprecated This property is deprecated. Use <code>FlxG.getTicks()</code> instead.
+		 */
+		static public function getTicks():uint
+		{
+			FlxG.warnDeprecated('FlxU.getTicks()', 'FlxG.getTicks()');
+			return FlxG.getTicks();
 		}
 	}
 }

--- a/src/flixel/util/FlxU.as
+++ b/src/flixel/util/FlxU.as
@@ -440,121 +440,6 @@ package flixel.util
 			return Velocity;
 		}
 		
-		//*** NOTE: THESE LAST THREE FUNCTIONS REQUIRE FLXPOINT ***//
-		
-		/**
-		 * Rotates a point in 2D space around another point by the given angle.
-		 * 
-		 * @param	X		The X coordinate of the point you want to rotate.
-		 * @param	Y		The Y coordinate of the point you want to rotate.
-		 * @param	PivotX	The X coordinate of the point you want to rotate around.
-		 * @param	PivotY	The Y coordinate of the point you want to rotate around.
-		 * @param	Angle	Rotate the point by this many degrees.
-		 * @param	Point	Optional <code>FlxPoint</code> to store the results in.
-		 * 
-		 * @return	A <code>FlxPoint</code> containing the coordinates of the rotated point.
-		 */
-		static public function rotatePoint(X:Number, Y:Number, PivotX:Number, PivotY:Number, Angle:Number,Point:FlxPoint=null):FlxPoint
-		{
-			var sin:Number = 0;
-			var cos:Number = 0;
-			var radians:Number = Angle * -0.017453293;
-			while (radians < -3.14159265)
-				radians += 6.28318531;
-			while (radians >  3.14159265)
-				radians = radians - 6.28318531;
-			
-			if (radians < 0)
-			{
-				sin = 1.27323954 * radians + .405284735 * radians * radians;
-				if (sin < 0)
-					sin = .225 * (sin *-sin - sin) + sin;
-				else
-					sin = .225 * (sin * sin - sin) + sin;
-			}
-			else
-			{
-				sin = 1.27323954 * radians - 0.405284735 * radians * radians;
-				if (sin < 0)
-					sin = .225 * (sin *-sin - sin) + sin;
-				else
-					sin = .225 * (sin * sin - sin) + sin;
-			}
-			
-			radians += 1.57079632;
-			if (radians >  3.14159265)
-				radians = radians - 6.28318531;
-			if (radians < 0)
-			{
-				cos = 1.27323954 * radians + 0.405284735 * radians * radians;
-				if (cos < 0)
-					cos = .225 * (cos *-cos - cos) + cos;
-				else
-					cos = .225 * (cos * cos - cos) + cos;
-			}
-			else
-			{
-				cos = 1.27323954 * radians - 0.405284735 * radians * radians;
-				if (cos < 0)
-					cos = .225 * (cos *-cos - cos) + cos;
-				else
-					cos = .225 * (cos * cos - cos) + cos;
-			}
-			
-			var dx:Number = X-PivotX;
-			var dy:Number = PivotY+Y; //Y axis is inverted in flash, normally this would be a subtract operation
-			if(Point == null)
-				Point = new FlxPoint();
-			Point.x = PivotX + cos*dx - sin*dy;
-			Point.y = PivotY - sin*dx - cos*dy;
-			return Point;
-		};
-		
-		/**
-		 * Calculates the angle between two points.  0 degrees points straight up.
-		 * 
-		 * @param	Point1		The X coordinate of the point.
-		 * @param	Point2		The Y coordinate of the point.
-		 * 
-		 * @return	The angle in degrees, between -180 and 180.
-		 */
-		static public function getAngle(Point1:FlxPoint, Point2:FlxPoint):Number
-		{
-			var x:Number = Point2.x - Point1.x;
-			var y:Number = Point2.y - Point1.y;
-			if((x == 0) && (y == 0))
-				return 0;
-			var c1:Number = 3.14159265 * 0.25;
-			var c2:Number = 3 * c1;
-			var ay:Number = (y < 0)?-y:y;
-			var angle:Number = 0;
-			if (x >= 0)
-				angle = c1 - c1 * ((x - ay) / (x + ay));
-			else
-				angle = c2 - c1 * ((x + ay) / (ay - x));
-			angle = ((y < 0)?-angle:angle)*57.2957796;
-			if(angle > 90)
-				angle = angle - 270;
-			else
-				angle += 90;
-			return angle;
-		};
-		
-		/**
-		 * Calculate the distance between two points.
-		 * 
-		 * @param Point1	A <code>FlxPoint</code> object referring to the first location.
-		 * @param Point2	A <code>FlxPoint</code> object referring to the second location.
-		 * 
-		 * @return	The distance between the two points as a floating point <code>Number</code> object.
-		 */
-		static public function getDistance(Point1:FlxPoint,Point2:FlxPoint):Number
-		{
-			var dx:Number = Point1.x - Point2.x;
-			var dy:Number = Point1.y - Point2.y;
-			return Math.sqrt(dx * dx + dy * dy);
-		}
-		
 		
 		/*     --- Deprecated members in Flixel v2.57 ---     */
 		/*  To be removed after developers have had time to adjust to the new changes. */
@@ -630,6 +515,59 @@ package flixel.util
 					return Objects[StartIndex + uint(Math.random()*l)];
 			}
 			return null;
+		}
+		
+		
+		/**
+		 * Rotates a point in 2D space around another point by the given angle.
+		 * 
+		 * @param	X		The X coordinate of the point you want to rotate.
+		 * @param	Y		The Y coordinate of the point you want to rotate.
+		 * @param	PivotX	The X coordinate of the point you want to rotate around.
+		 * @param	PivotY	The Y coordinate of the point you want to rotate around.
+		 * @param	Angle	Rotate the point by this many degrees.
+		 * @param	Point	Optional <code>FlxPoint</code> to store the results in.
+		 * 
+		 * @return	A <code>FlxPoint</code> containing the coordinates of the rotated point.
+		 * 
+		 * @deprecated This property is deprecated. Use <code>FlxPoint.rotate()</code> instead.
+		 */
+		static public function rotatePoint(X:Number, Y:Number, pivotX:Number, pivotY:Number, angle:Number, point:FlxPoint=null):FlxPoint
+		{
+			FlxG.warnDeprecated('FlxU.rotatePoint()', 'FlxPoint.rotate()');
+			return FlxPoint.rotate(X, Y, pivotX, pivotY, angle, point);
+		}
+		
+		/**
+		 * Calculates the angle between two points.  0 degrees points straight up.
+		 * 
+		 * @param	Point1		The X coordinate of the point.
+		 * @param	Point2		The Y coordinate of the point.
+		 * 
+		 * @return	The angle in degrees, between -180 and 180.
+		 * 
+		 * @deprecated This property is deprecated. Use <code>FlxPoint.angleBetween()</code> instead.
+		 */
+		static public function getAngle(point1:FlxPoint, point2:FlxPoint):Number
+		{
+			FlxG.warnDeprecated('FlxU.getAngle()', 'FlxPoint.angleBetween()');
+			return FlxPoint.angleBetween(point1, point2);
+		}
+		
+		/**
+		 * Calculate the distance between two points.
+		 * 
+		 * @param Point1	A <code>FlxPoint</code> object referring to the first location.
+		 * @param Point2	A <code>FlxPoint</code> object referring to the second location.
+		 * 
+		 * @return	The distance between the two points as a floating point <code>Number</code> object.
+		 * 
+		 * @deprecated This property is deprecated. Use <code>FlxPoint.distance()</code> instead.
+		 */
+		static public function getDistance(point1:FlxPoint, point2:FlxPoint):Number
+		{
+			FlxG.warnDeprecated('FlxU.getDistance()', 'FlxPoint.distance()');
+			return FlxPoint.distance(point1, point2);
 		}
 		
 	}


### PR DESCRIPTION
Move several methods to new locations (as per [the FlxMath planning spreadsheet](https://docs.google.com/spreadsheet/ccc?key=0Avkk09kHolxjdEJPaHJMeFJmZTV1Rkt4bGgzV01HcVE&usp=sharing#gid=0))

```
FlxU.rotatePoint() -> FlxPoint.rotate()
FlxU.getAngle()    -> FlxPoint.angleBetween()
FlxU.getDistance() -> FlxPoint.distance()

FlxU.abs()   -> FlxMath.abs()
FlxU.floor() -> FlxMath.floor()
FlxU.ceil()  -> FlxMath.ceil()
FlxU.round() -> FlxMath.round()
FlxU.min()   -> FlxMath.min()
FlxU.max()   -> FlxMath.max()
FlxU.bound() -> FlxMath.clamp()

FlxU.getTicks() -> FlxG.getTicks()
```
