### PR TITLE
Fix_157: Create FlxToolbar. Repeat of #160.

### DIFF
--- a/src/flixel/system/debug/FlxToolbar.as
+++ b/src/flixel/system/debug/FlxToolbar.as
@@ -1,0 +1,132 @@
+package flixel.system.debug 
+{
+	import flash.display.Sprite;
+	import flash.events.Event;
+	import flash.events.MouseEvent;
+	
+	/**
+	 * Parent for debugger toolbars
+	 * 
+	 * @author greysondn
+	 * @author Adam Atomic
+	 */
+	public class FlxToolbar extends Sprite 
+	{
+		
+		public function FlxToolbar() 
+		{
+			super();	
+		}
+		
+		/**
+		 * Clean up memory.
+		 */
+		public function destroy():void
+		{
+			// remove this object's mouse listeners from parent
+			if (parent)
+			{
+				parent.removeEventListener(MouseEvent.MOUSE_MOVE,handleMouseMove);
+				parent.removeEventListener(MouseEvent.MOUSE_DOWN,handleMouseDown);
+				parent.removeEventListener(MouseEvent.MOUSE_UP,handleMouseUp);
+			}
+		}
+		
+		/**
+		 * Override to implement logic to check which button the mouse is over (if any)
+		 * and handle any special logic you'd like to implement upon that.
+		 * 
+		 * Note that the default implementation returns false. Always.
+		 */
+		protected function checkOver():Boolean
+		{
+			// pass, basically
+			return false;
+		}		
+		
+		/**
+		 * Override to implement highlighting of buttons based upon which the mouse is over.
+		 */
+		protected function updateGUI():void
+		{
+			// pass
+		}
+		
+		/**
+		 * Mark buttons as unpressed, check which buttons the mouse is over,
+		 * and update highlight and GUI accordingly.
+		 * 
+		 * Note that this only consolidates three commonly called functions into
+		 * one. It is equivalent to calling:
+		 *	* unpress();
+		 * 	* checkOver();
+		 * 	* updateGUI();
+		 */
+		protected function updateGUIFromMouse():void
+		{
+			unpress();
+			checkOver();
+			updateGUI();
+		}
+		
+		/**
+		 * Override this function to reset any variables set when a button
+		 * is pressed to their default "unpressed" value.
+		 */
+		protected function unpress():void
+		{
+			// pass
+		}
+		
+		//***EVENT HANDLERS***//
+		
+		/**
+		 * Just sets up basic mouse listeners, a la FlxWindow.
+		 * 
+		 * @param	E	Flash event.
+		 */
+		protected function init(E:Event=null):void
+		{
+			if(root == null)
+				return;
+			removeEventListener(Event.ENTER_FRAME,init);
+			
+			parent.addEventListener(MouseEvent.MOUSE_MOVE,handleMouseMove);
+			parent.addEventListener(MouseEvent.MOUSE_DOWN,handleMouseDown);
+			parent.addEventListener(MouseEvent.MOUSE_UP,handleMouseUp);
+		}
+		
+		/**
+		 * If the mouse moves, check to see if any buttons should be highlighted.
+		 * 
+		 * @param	E	Flash mouse event.
+		 */
+		protected function handleMouseMove(E:MouseEvent=null):void
+		{
+			if(!checkOver())
+				unpress();
+			updateGUI();
+		}
+		
+		/**
+		 * Override to check if a specific button is pressed down.
+		 * 
+		 * @param	E	Flash mouse event.
+		 */
+		protected function handleMouseDown(E:MouseEvent=null):void
+		{
+			unpress();
+		}
+		
+		/**
+		 * Override to check if mouse was released over a pressed button.
+		 * 
+		 * @param	E	Flash mouse event
+		 */
+		protected function handleMouseUp(E:MouseEvent=null):void
+		{
+			// pass
+		}
+	}
+
+}

--- a/src/flixel/system/debug/VCR.as
+++ b/src/flixel/system/debug/VCR.as
@@ -494,7 +494,7 @@ package flixel.system.debug
 		 */
 		override protected function checkOver():Boolean 
 		{
-			return super.checkOver();
+			super.checkOver();
 			
 			_overOpen = _overRecord = _overRestart = _overPause = _overStep = false;
 			if((mouseX < 0) || (mouseX > width) || (mouseY < 0) || (mouseY > 15))

--- a/src/flixel/system/debug/VCR.as
+++ b/src/flixel/system/debug/VCR.as
@@ -20,7 +20,7 @@ package flixel.system.debug
 	 * 
 	 * @author Adam Atomic
 	 */
-	public class VCR extends Sprite
+	public class VCR extends FlxToolbar
 	{
 		[Embed(source="../../assets/vcr/open.png")] protected var ImgOpen:Class;
 		[Embed(source="../../assets/vcr/record_off.png")] protected var ImgRecordOff:Class;
@@ -132,10 +132,8 @@ package flixel.system.debug
 			
 			stepRequested = false;
 			_file = null;
-
-			unpress();
-			checkOver();
-			updateGUI();
+			
+			updateGUIFromMouse();
 			
 			addEventListener(Event.ENTER_FRAME,init);
 		}
@@ -143,8 +141,8 @@ package flixel.system.debug
 		/**
 		 * Clean up memory.
 		 */
-		public function destroy():void
-		{
+		override public function destroy():void 
+		{			
 			_file = null;
 			
 			if (_open) removeChild(_open);
@@ -166,12 +164,7 @@ package flixel.system.debug
 			if (_step) removeChild(_step);
 			_step = null;
 			
-			if (parent)
-			{
-				parent.removeEventListener(MouseEvent.MOUSE_MOVE,handleMouseMove);
-				parent.removeEventListener(MouseEvent.MOUSE_DOWN,handleMouseDown);
-				parent.removeEventListener(MouseEvent.MOUSE_UP,handleMouseUp);
-			}
+			super.destroy();
 		}
 		
 		/**
@@ -435,41 +428,14 @@ package flixel.system.debug
 		//***EVENT HANDLERS***//
 		
 		/**
-		 * Just sets up basic mouse listeners, a la FlxWindow.
-		 * 
-		 * @param	E	Flash event.
-		 */
-		protected function init(E:Event=null):void
-		{
-			if(root == null)
-				return;
-			removeEventListener(Event.ENTER_FRAME,init);
-
-			parent.addEventListener(MouseEvent.MOUSE_MOVE,handleMouseMove);
-			parent.addEventListener(MouseEvent.MOUSE_DOWN,handleMouseDown);
-			parent.addEventListener(MouseEvent.MOUSE_UP,handleMouseUp);
-		}
-		
-		/**
-		 * If the mouse moves, check to see if any buttons should be highlighted.
-		 * 
-		 * @param	E	Flash mouse event.
-		 */
-		protected function handleMouseMove(E:MouseEvent=null):void
-		{
-			if(!checkOver())
-				unpress();
-			updateGUI();
-		}
-		
-		/**
 		 * If the mouse is pressed down, check to see if the user started pressing down a specific button.
 		 * 
 		 * @param	E	Flash mouse event.
 		 */
-		protected function handleMouseDown(E:MouseEvent=null):void
+		override protected function handleMouseDown(E:MouseEvent = null):void 
 		{
-			unpress();
+			super.handleMouseDown(E);
+			
 			if(_overOpen)
 				_pressingOpen = true;
 			if(_overRecord)
@@ -488,8 +454,10 @@ package flixel.system.debug
 		 * 
 		 * @param	E	Flash mouse event.
 		 */
-		protected function handleMouseUp(E:MouseEvent=null):void
+		override protected function handleMouseUp(E:MouseEvent = null):void 
 		{
+			super.handleMouseUp(E);
+			
 			if(_overOpen && _pressingOpen)
 				onOpen();
 			else if(_overRecord && _pressingRecord)
@@ -513,9 +481,7 @@ package flixel.system.debug
 			else if(_overStep && _pressingStep)
 				onStep();
 			
-			unpress();
-			checkOver();
-			updateGUI();
+			updateGUIFromMouse();
 		}
 		
 		//***MISC GUI MGMT STUFF***//
@@ -526,8 +492,10 @@ package flixel.system.debug
 		 * 
 		 * @return	Whether the mouse was over any buttons or not.
 		 */
-		protected function checkOver():Boolean
+		override protected function checkOver():Boolean 
 		{
+			return super.checkOver();
+			
 			_overOpen = _overRecord = _overRestart = _overPause = _overStep = false;
 			if((mouseX < 0) || (mouseX > width) || (mouseY < 0) || (mouseY > 15))
 				return false;
@@ -550,8 +518,10 @@ package flixel.system.debug
 		/**
 		 * Sets all the pressed state variables for the buttons to false.
 		 */
-		protected function unpress():void
+		override protected function unpress():void 
 		{
+			super.unpress();
+			
 			_pressingOpen = false;
 			_pressingRecord = false;
 			_pressingRestart = false;
@@ -562,8 +532,10 @@ package flixel.system.debug
 		/**
 		 * Figures out what buttons to highlight based on the _overWhatever and _pressingWhatever variables.
 		 */
-		protected function updateGUI():void
+		override protected function updateGUI():void 
 		{
+			super.updateGUI();
+			
 			if(_recordOn.visible)
 			{
 				_open.alpha = _restart.alpha = _pause.alpha = _step.alpha = 0.35;

--- a/src/flixel/system/debug/Vis.as
+++ b/src/flixel/system/debug/Vis.as
@@ -13,7 +13,7 @@ package flixel.system.debug
 	 * 
 	 * @author Adam Atomic
 	 */
-	public class Vis extends Sprite
+	public class Vis extends FlxToolbar
 	{
 		[Embed(source="../../assets/vis/bounds.png")] protected var ImgBounds:Class;
 
@@ -31,9 +31,7 @@ package flixel.system.debug
 			_bounds = new ImgBounds();
 			addChild(_bounds);
 			
-			unpress();
-			checkOver();
-			updateGUI();
+			updateGUIFromMouse();
 			
 			addEventListener(Event.ENTER_FRAME,init);
 		}
@@ -41,7 +39,7 @@ package flixel.system.debug
 		/**
 		 * Clean up memory.
 		 */
-		public function destroy():void
+		override public function destroy():void 
 		{
 			if (_bounds) removeChild(_bounds);
 			_bounds = null;
@@ -52,6 +50,8 @@ package flixel.system.debug
 				parent.removeEventListener(MouseEvent.MOUSE_DOWN,handleMouseDown);
 				parent.removeEventListener(MouseEvent.MOUSE_UP,handleMouseUp);
 			}
+			
+			super.destroy();
 		}
 		
 		//***ACTUAL BUTTON BEHAVIORS***//
@@ -67,41 +67,14 @@ package flixel.system.debug
 		//***EVENT HANDLERS***//
 		
 		/**
-		 * Just sets up basic mouse listeners, a la FlxWindow.
-		 * 
-		 * @param	E	Flash event.
-		 */
-		protected function init(E:Event=null):void
-		{
-			if(root == null)
-				return;
-			removeEventListener(Event.ENTER_FRAME,init);
-			
-			parent.addEventListener(MouseEvent.MOUSE_MOVE,handleMouseMove);
-			parent.addEventListener(MouseEvent.MOUSE_DOWN,handleMouseDown);
-			parent.addEventListener(MouseEvent.MOUSE_UP,handleMouseUp);
-		}
-		
-		/**
-		 * If the mouse moves, check to see if any buttons should be highlighted.
-		 * 
-		 * @param	E	Flash mouse event.
-		 */
-		protected function handleMouseMove(E:MouseEvent=null):void
-		{
-			if(!checkOver())
-				unpress();
-			updateGUI();
-		}
-		
-		/**
 		 * If the mouse is pressed down, check to see if the user started pressing down a specific button.
 		 * 
 		 * @param	E	Flash mouse event.
 		 */
-		protected function handleMouseDown(E:MouseEvent=null):void
+		override protected function handleMouseDown(E:MouseEvent = null):void 
 		{
-			unpress();
+			super.handleMouseDown(E);
+			
 			if(_overBounds)
 				_pressingBounds = true;
 		}
@@ -112,13 +85,14 @@ package flixel.system.debug
 		 * 
 		 * @param	E	Flash mouse event.
 		 */
-		protected function handleMouseUp(E:MouseEvent=null):void
+		override protected function handleMouseUp(E:MouseEvent=null):void
 		{
+			super.handleMouseUp();
+			
 			if(_overBounds && _pressingBounds)
 				onBounds();
-			unpress();
-			checkOver();
-			updateGUI();
+			
+			updateGUIFromMouse();
 		}
 		
 		//***MISC GUI MGMT STUFF***//
@@ -129,29 +103,42 @@ package flixel.system.debug
 		 * 
 		 * @return	Whether the mouse was over any buttons or not.
 		 */
-		protected function checkOver():Boolean
-		{
+		override protected function checkOver():Boolean
+		{	
+			super.checkOver();
+			
 			_overBounds = false;
-			if((mouseX < 0) || (mouseX > width) || (mouseY < 0) || (mouseY > height))
+			
+			if ((mouseX < 0) || (mouseX > width) || (mouseY < 0) || (mouseY > height))
+			{
 				return false;
-			if((mouseX > _bounds.x) || (mouseX < _bounds.x + _bounds.width))
+			}
+			
+			if ((mouseX > _bounds.x) || (mouseX < _bounds.x + _bounds.width))
+			{
 				_overBounds = true;
+			}
+			
 			return true;
 		}
 		
 		/**
 		 * Sets all the pressed state variables for the buttons to false.
 		 */
-		protected function unpress():void
+		override protected function unpress():void 
 		{
+			super.unpress();
+			
 			_pressingBounds = false;
 		}
 		
 		/**
 		 * Figures out what buttons to highlight based on the _overWhatever and _pressingWhatever variables.
 		 */
-		protected function updateGUI():void
+		override protected function updateGUI():void 
 		{
+			super.updateGUI();
+			
 			if(FlxG.visualDebug)
 			{
 				if(_overBounds && (_bounds.alpha != 1.0))


### PR DESCRIPTION
> > Fixes #157, Repeats #160

I would suggest seeing #160 for an excess of discussion about roughly the same work.

Recommendations moving forwards...

Are we merging in Flixel Power Tools? (I suggested this in #163) Most of the logic here is really a fudge that breaks what I feel is proper object orientation; buttons should be responsible for themselves and FlxButton from the Power Tools kit would be - in effect - what I'd end up writing if I'd extract them to do as such within the scope of how Flixel works. I believe @IQAndreas had hinted at similar work (and a few ideas were tossed around besides) in #160's conversation.

Beyond that the new class is semi-abstract. I've sort of cherry picked what I feel is correct for a parent (or, rather, not incorrect) and this results in a couple of functions that exist purely as placeholders (their bodies will have a "pass" comment).

If there's any notes on this work or anything that I could do let me know. I have done preliminary testing and everything seems sound - however, it never hurts to do extra testing, especially for something so important :)
