### PR TITLE
Make Flixel GPU accelerated

### DIFF
--- a/src/flixel/FlxBasic.as
+++ b/src/flixel/FlxBasic.as
@@ -38,6 +38,13 @@ package flixel
 		 */
 		public var alive:Boolean;
 		/**
+		 * An array of camera objects that this object will use during <code>draw()</code>.
+		 * This value will initialize itself during the first draw to automatically
+		 * point at the main camera list out in <code>FlxG</code> unless you already set it.
+		 * You can also change it afterward too, very flexible!
+		 */
+		public var cameras:Array;
+		/**
 		 * Setting this to true will prevent the object from appearing
 		 * when the visual debug mode in the debugger overlay is toggled on.
 		 */
@@ -61,7 +68,14 @@ package flixel
 		 * <code>destroy()</code> on class members if necessary.
 		 * Don't forget to call <code>super.destroy()</code>!
 		 */
-		public function destroy():void {}
+		public function destroy():void
+		{
+			if (cameras != null)
+			{
+				cameras.length = 0;
+				cameras = null;
+			}
+		}
 		
 		/**
 		 * Pre-update is called right before <code>update()</code> on each object in the game loop.

--- a/src/flixel/FlxBasic.as
+++ b/src/flixel/FlxBasic.as
@@ -38,13 +38,6 @@ package flixel
 		 */
 		public var alive:Boolean;
 		/**
-		 * An array of camera objects that this object will use during <code>draw()</code>.
-		 * This value will initialize itself during the first draw to automatically
-		 * point at the main camera list out in <code>FlxG</code> unless you already set it.
-		 * You can also change it afterward too, very flexible!
-		 */
-		public var cameras:Array;
-		/**
 		 * Setting this to true will prevent the object from appearing
 		 * when the visual debug mode in the debugger overlay is toggled on.
 		 */
@@ -94,23 +87,17 @@ package flixel
 		}
 		
 		/**
-		 * Override this function to control how the object is drawn.
+		 * Override this function to control how the object is drawn. The Flixel render will call 
+		 * this function for every each active camera found in <code>FlxG.cameras</code>.
 		 * Overriding <code>draw()</code> is rarely necessary, but can be very useful.
+		 * 
+		 * @param	Camera	The camera where the object will draw itself to.
 		 */
-		public function draw():void
+		public function draw(Camera:FlxCamera):void
 		{
-			if(cameras == null)
-				cameras = FlxG.cameras;
-			var camera:FlxCamera;
-			var i:uint = 0;
-			var l:uint = cameras.length;
-			while(i < l)
-			{
-				camera = cameras[i++];
-				_VISIBLECOUNT++;
-				if(FlxG.visualDebug && !ignoreDrawDebug)
-					drawDebug(camera);
-			}
+			_VISIBLECOUNT++;
+			if(FlxG.visualDebug && !ignoreDrawDebug)
+				drawDebug(Camera);
 		}
 		
 		/**

--- a/src/flixel/FlxCamera.as
+++ b/src/flixel/FlxCamera.as
@@ -304,6 +304,7 @@ package flixel
 			if (bgTexture != null)
 			{
 				bgTexture.destroy();
+				bgTexture = null;
 			}
 			
 			super.destroy();

--- a/src/flixel/FlxCamera.as
+++ b/src/flixel/FlxCamera.as
@@ -98,6 +98,7 @@ package flixel
 		public var scroll:FlxPoint;
 		/**
 		 * The actual bitmap data of the camera display itself.
+		 * TODO: Render: Check if it is necessary.
 		 */
 		public var buffer:BitmapData;
 		/**

--- a/src/flixel/FlxCamera.as
+++ b/src/flixel/FlxCamera.as
@@ -708,7 +708,7 @@ package flixel
 		/**
 		 * Internal helper function, handles the actual drawing of all the special effects.
 		 */
-		internal function drawFX():void
+		public function drawFX():void
 		{
 			var alphaComponent:Number;
 			

--- a/src/flixel/FlxCamera.as
+++ b/src/flixel/FlxCamera.as
@@ -304,7 +304,7 @@ package flixel
 			
 			if (texture != null)
 			{
-				texture.dispose();
+				texture.dispose(); // TODO: Render: instead of using a texture here, use the Render's internal buffer.
 				texture = null;
 			}
 			
@@ -729,6 +729,15 @@ package flixel
 		public function set fxColorAcumulator(Value:uint):void
 		{
 			_fxColorAcumulator = Value;
+		}
+		
+		/**
+		 * The amount of movement the camera is currently shaking in each axis when the <code>shake()</code>
+		 * effect has been activated.
+		 */
+		public function get fxShakeOffset():FlxPoint
+		{
+			return _fxShakeOffset;
 		}
 		
 		/**

--- a/src/flixel/FlxCamera.as
+++ b/src/flixel/FlxCamera.as
@@ -1,17 +1,14 @@
 package flixel
 {
-	import com.genome2d.textures.factories.GTextureFactory;
-	import com.genome2d.textures.GTexture;
 	import flash.display.Bitmap;
 	import flash.display.BitmapData;
 	import flash.display.Sprite;
 	import flash.geom.ColorTransform;
 	import flash.geom.Point;
 	import flash.geom.Rectangle;
-	import flixel.system.render.blitting.FlxBlittingRender;
-	import flixel.system.render.genome2d.FlxGenome2DRender;
-	import flixel.util.FlxU;
+	import flixel.system.render.FlxTexture;
 	
+	import flixel.util.FlxU;
 	import flixel.util.FlxMath;
 	import flixel.util.FlxPoint;
 	import flixel.util.FlxRect;
@@ -107,14 +104,10 @@ package flixel
 		 */
 		public var buffer:BitmapData;
 		/**
-		 * TODO: Render: add docs
+		 * A texture representing the camera background. It's used to render the camera when Flixel is in GPU-mode.
+		 * TODO: try to remove this property and use screen.texture (or equivalent) instead.
 		 */
-		public var texture:GTexture;
-		/**
-		 * The natural background color of the camera. Defaults to FlxG.bgColor.
-		 * NOTE: can be transparent for crazy FX!
-		 */
-		protected var _bgColor:uint;
+		public var bgTexture:FlxTexture;
 		/**
 		 * Sometimes it's easier to just work with a <code>FlxSprite</code> than it is to work
 		 * directly with the <code>BitmapData</code> buffer.  This sprite reference will
@@ -122,6 +115,11 @@ package flixel
 		 */
 		public var screen:FlxSprite;
 		
+		/**
+		 * The natural background color of the camera. Defaults to FlxG.bgColor.
+		 * NOTE: can be transparent for crazy FX!
+		 */
+		protected var _bgColor:uint;
 		/**
 		 * Indicates how far the camera is zoomed in.
 		 */
@@ -245,6 +243,7 @@ package flixel
 			screen.makeGraphic(width,height,0,true);
 			screen.setOriginToCorner();
 			buffer = screen.pixels;
+			bgTexture = new FlxTexture();
 			bgColor = FlxG.bgColor;
 			_color = 0xffffff;
 
@@ -302,10 +301,9 @@ package flixel
 			_fxShakeOffset = null;
 			_fill = null;
 			
-			if (texture != null)
+			if (bgTexture != null)
 			{
-				texture.dispose(); // TODO: Render: instead of using a texture here, use the Render's internal buffer.
-				texture = null;
+				bgTexture.destroy();
 			}
 			
 			super.destroy();
@@ -664,16 +662,10 @@ package flixel
 		{
 			_bgColor = Color;
 			
-			if (texture != null)
+			if (!FlxG.render.isBlitting())
 			{
-				texture.dispose();
-				texture = null;
-			}
-			
-			if (FlxG.render is FlxGenome2DRender)
-			{
-				var bitmapData:BitmapData = new BitmapData(width, height, false, Color);
-				texture = GTextureFactory.createFromBitmapData("FlxCamera" + Math.random(), bitmapData);
+				// TODO: it could be improved by creating a 1x1 px texture that will be scaled during GPU render.
+				bgTexture.makeGraphic(width, height, Color);
 			}
 		}
 		
@@ -788,7 +780,7 @@ package flixel
 			// If the current render is not blitting there is no need
 			// to fill buffers and stuff, because only _fxColorAcumulator will be
 			// used to draw the effects.
-			if (!(FlxG.render is FlxBlittingRender)) return;			
+			if (!FlxG.render.isBlitting()) return;
 			
 			alpha = Color >> 24 & 0xFF;
 

--- a/src/flixel/FlxCamera.as
+++ b/src/flixel/FlxCamera.as
@@ -100,7 +100,6 @@ package flixel
 		public var scroll:FlxPoint;
 		/**
 		 * The actual bitmap data of the camera display itself.
-		 * TODO: Render: Check if it is necessary.
 		 */
 		public var buffer:BitmapData;
 		/**
@@ -680,14 +679,6 @@ package flixel
 		}
 		
 		/**
-		 * TODO: Render: add docs
-		 */
-		public function get colorTransform():ColorTransform
-		{
-			return _flashBitmap.transform.colorTransform;
-		}
-		
-		/**
 		 * Whether the camera display is smooth and filtered, or chunky and pixelated.
 		 * Default behavior is chunky-style.
 		 */
@@ -717,7 +708,11 @@ package flixel
 		}
 		
 		/**
-		 * TODO: Render: add docs
+		 * The current color being added to the buffer because of any visual effect (e.g. flash or fade).
+		 * When an effect is in place, such as after calling <code>fade()</code>, the effect's color
+		 * must be added to the camera buffer. When there are more than one active effect, their color
+		 * is accumulated (blended) and drawn to the camera buffer.
+		 * This property stores the current accumulated color being draw to the buffer.
 		 */
 		public function set fxColorAcumulator(Value:uint):void
 		{

--- a/src/flixel/FlxCamera.as
+++ b/src/flixel/FlxCamera.as
@@ -1,11 +1,15 @@
 package flixel
 {
+	import com.genome2d.textures.factories.GTextureFactory;
+	import com.genome2d.textures.GTexture;
 	import flash.display.Bitmap;
 	import flash.display.BitmapData;
 	import flash.display.Sprite;
 	import flash.geom.ColorTransform;
 	import flash.geom.Point;
 	import flash.geom.Rectangle;
+	import flixel.system.render.genome2d.FlxGenome2DRender;
+	import flixel.util.FlxU;
 	
 	import flixel.util.FlxMath;
 	import flixel.util.FlxPoint;
@@ -102,10 +106,14 @@ package flixel
 		 */
 		public var buffer:BitmapData;
 		/**
+		 * TODO: Render: add docs
+		 */
+		public var texture:GTexture;
+		/**
 		 * The natural background color of the camera. Defaults to FlxG.bgColor.
 		 * NOTE: can be transparent for crazy FX!
 		 */
-		public var bgColor:uint;
+		protected var _bgColor:uint;
 		/**
 		 * Sometimes it's easier to just work with a <code>FlxSprite</code> than it is to work
 		 * directly with the <code>BitmapData</code> buffer.  This sprite reference will
@@ -287,6 +295,13 @@ package flixel
 			_fxShakeComplete = null;
 			_fxShakeOffset = null;
 			_fill = null;
+			
+			if (texture != null)
+			{
+				texture.dispose();
+				texture = null;
+			}
+			
 			super.destroy();
 		}
 		
@@ -632,6 +647,45 @@ package flixel
 			colorTransform.greenMultiplier = (_color>>8&0xff)*0.00392;
 			colorTransform.blueMultiplier = (_color&0xff)*0.00392;
 			_flashBitmap.transform.colorTransform = colorTransform;
+		}
+		
+		/**
+		 * The natural background color of the camera. Defaults to <code>FlxG.bgColor</code>.
+		 * NOTE: can be transparent for crazy FX!
+		 */
+		
+		public function set bgColor(Color:uint):void
+		{
+			_bgColor = Color;
+			
+			if (texture != null)
+			{
+				texture.dispose();
+				texture = null;
+			}
+			
+			if (FlxG.render is FlxGenome2DRender)
+			{
+				var bitmapData:BitmapData = new BitmapData(width, height, false, Color);
+				texture = GTextureFactory.createFromBitmapData("FlxCamera" + Math.random(), bitmapData);
+			}
+		}
+		
+		/**
+		 * The natural background color of the camera. Defaults to <code>FlxG.bgColor</code>.
+		 * NOTE: can be transparent for crazy FX!
+		 */
+		public function get bgColor():uint
+		{
+			return _bgColor;
+		}
+		
+		/**
+		 * TODO: Render: add docs
+		 */
+		public function get colorTransform():ColorTransform
+		{
+			return _flashBitmap.transform.colorTransform;
 		}
 		
 		/**

--- a/src/flixel/FlxG.as
+++ b/src/flixel/FlxG.as
@@ -1,6 +1,7 @@
 package flixel
 {
 	import flash.utils.getTimer;
+	import flixel.system.render.FlxRender;
 	import flixel.util.FlxRandom;
 	import flixel.util.FlxU;
 	import flixel.system.FlxSound;
@@ -699,6 +700,15 @@ package flixel
 		static public function get state():FlxState
 		{
 			return _game._state;
+		}
+		
+		/**
+		 * TODO: Render: add docs
+		 * Read-only: access the game render.
+		 */
+		static public function get render():FlxRender
+		{
+			return _game._render;
 		}
 		
 		/**

--- a/src/flixel/FlxG.as
+++ b/src/flixel/FlxG.as
@@ -1080,47 +1080,6 @@ package flixel
 		}
 		
 		/**
-		 * Called by the game object to lock all the camera buffers and clear them for the next draw pass.
-		 */
-		static internal function lockCameras():void
-		{
-			var cam:FlxCamera;
-			var cams:Array = FlxG.cameras;
-			var i:uint = 0;
-			var l:uint = cams.length;
-			while(i < l)
-			{
-				cam = cams[i++] as FlxCamera;
-				if((cam == null) || !cam.exists || !cam.visible)
-					continue;
-				if(useBufferLocking)
-					cam.buffer.lock();
-				cam.fill(cam.bgColor);
-				cam.screen.dirty = true;
-			}
-		}
-		
-		/**
-		 * Called by the game object to draw the special FX and unlock all the camera buffers.
-		 */
-		static internal function unlockCameras():void
-		{
-			var cam:FlxCamera;
-			var cams:Array = FlxG.cameras;
-			var i:uint = 0;
-			var l:uint = cams.length;
-			while(i < l)
-			{
-				cam = cams[i++] as FlxCamera;
-				if((cam == null) || !cam.exists || !cam.visible)
-					continue;
-				cam.drawFX();
-				if(useBufferLocking)
-					cam.buffer.unlock();
-			}
-		}
-		
-		/**
 		 * Called by the game object to update the cameras and their tracking/special effects logic.
 		 */
 		static internal function updateCameras():void

--- a/src/flixel/FlxG.as
+++ b/src/flixel/FlxG.as
@@ -750,7 +750,7 @@ package flixel
 		 */
 		static public function addCamera(NewCamera:FlxCamera):FlxCamera
 		{
-			if (FlxG.render is FlxBlittingRender)
+			if (FlxG.render.isBlitting())
 			{
 				FlxG._game.addChildAt(NewCamera._flashSprite,FlxG._game.getChildIndex(FlxG._game._mouse));
 			}

--- a/src/flixel/FlxG.as
+++ b/src/flixel/FlxG.as
@@ -1,6 +1,7 @@
 package flixel
 {
 	import flash.utils.getTimer;
+	import flixel.system.render.blitting.FlxBlittingRender;
 	import flixel.system.render.FlxRender;
 	import flixel.util.FlxRandom;
 	import flixel.util.FlxU;
@@ -749,7 +750,10 @@ package flixel
 		 */
 		static public function addCamera(NewCamera:FlxCamera):FlxCamera
 		{
-			FlxG._game.addChildAt(NewCamera._flashSprite,FlxG._game.getChildIndex(FlxG._game._mouse));
+			if (FlxG.render is FlxBlittingRender)
+			{
+				FlxG._game.addChildAt(NewCamera._flashSprite,FlxG._game.getChildIndex(FlxG._game._mouse));
+			}
 			FlxG.cameras.push(NewCamera);
 			return NewCamera;
 		}
@@ -762,10 +766,13 @@ package flixel
 		 */
 		static public function removeCamera(Camera:FlxCamera,Destroy:Boolean=true):void
 		{
-			if(Camera && FlxG._game.contains(Camera._flashSprite))
+			if(Camera && FlxG.cameras.indexOf(Camera) != -1)
 			{
 				FlxG.cameras.splice(FlxG.cameras.indexOf(Camera), 1);
-				FlxG._game.removeChild(Camera._flashSprite);
+				if (Camera._flashSprite.parent != null)
+				{
+					Camera._flashSprite.parent.removeChild(Camera._flashSprite);
+				}
 			}
 			else 
 				FlxG.log("Error removing camera, not part of game.");
@@ -788,7 +795,10 @@ package flixel
 			while(i < l)
 			{
 				cam = FlxG.cameras[i++] as FlxCamera;
-				FlxG._game.removeChild(cam._flashSprite);
+				if (cam._flashSprite.parent != null)
+				{
+					cam._flashSprite.parent.removeChild(cam._flashSprite);
+				}
 				cam.destroy();
 			}
 			FlxG.cameras.length = 0;

--- a/src/flixel/FlxG.as
+++ b/src/flixel/FlxG.as
@@ -704,8 +704,7 @@ package flixel
 		}
 		
 		/**
-		 * TODO: Render: add docs
-		 * Read-only: access the game render.
+		 * Read-only: access the game render. You can select a CPU or a GPU render during the game creation.
 		 */
 		static public function get render():FlxRender
 		{

--- a/src/flixel/FlxGame.as
+++ b/src/flixel/FlxGame.as
@@ -58,7 +58,7 @@ package flixel
 		/**
 		 * TODO: add docs about render
 		 */
-		protected var _render:FlxRender;
+		internal var _render:FlxRender;
 		/**
 		 * Current game state.
 		 */
@@ -551,7 +551,7 @@ package flixel
 			
 			// TODO: add docs
 			// TODO: init render based on Class coming from FlxGame constructor
-			_render = new FlxGenome2DRender();
+			_render = new FlxBlittingRender();
 			_render.init(this, onEnterFrame);
 		}
 		

--- a/src/flixel/FlxGame.as
+++ b/src/flixel/FlxGame.as
@@ -551,7 +551,7 @@ package flixel
 			
 			// TODO: add docs
 			// TODO: init render based on Class coming from FlxGame constructor
-			_render = new FlxBlittingRender();
+			_render = new FlxGenome2DRender();
 			_render.init(this, onEnterFrame);
 		}
 		

--- a/src/flixel/FlxGame.as
+++ b/src/flixel/FlxGame.as
@@ -19,9 +19,8 @@ package flixel
 	import flixel.system.FlxSave;
 	import flixel.system.debug.FlxDebugger;
 	
-	// TODO: clean this up
-	import flixel.system.render.blitting.FlxBlittingRender;
 	import flixel.system.render.FlxRender;
+	import flixel.system.render.blitting.FlxBlittingRender;
 	import flixel.system.render.genome2d.FlxGenome2DRender;
 
 	/**
@@ -56,9 +55,14 @@ package flixel
 		public var forceDebugger:Boolean;
 
 		/**
-		 * TODO: add docs about render
+		 * The render flixel is using to draw things into the screen.
+		 * All available renders are in the <code>system.render</code> package.
 		 */
 		internal var _render:FlxRender;
+		/**
+		 * Tells flixel to use hardware acceleration (Stage3D) to draw things.
+		 */
+		internal var _useGPU:Boolean;
 		/**
 		 * Current game state.
 		 */
@@ -147,8 +151,9 @@ package flixel
 		 * @param	GameFramerate	How frequently the game should update (default is 60 times per second).
 		 * @param	FlashFramerate	Sets the actual display framerate for Flash player (default is 30 times per second).
 		 * @param	UseSystemCursor	Whether to use the default OS mouse pointer, or to use custom flixel ones.
+		 * @param	UseGPU			Whether to use hardware acceleration for rendering (with Genome2D). Default is <code>false</code> (meaning that flixel must use blitting to render things).
 		 */
-		public function FlxGame(GameSizeX:uint,GameSizeY:uint,InitialState:Class,Zoom:Number=1,GameFramerate:uint=60,FlashFramerate:uint=30,UseSystemCursor:Boolean=false)
+		public function FlxGame(GameSizeX:uint,GameSizeY:uint,InitialState:Class,Zoom:Number=1,GameFramerate:uint=60,FlashFramerate:uint=30,UseSystemCursor:Boolean=false,UseGPU:Boolean=false)
 		{
 			//super high priority init stuff (focus, mouse, etc)
 			_lostFocus = false;
@@ -176,6 +181,10 @@ package flixel
 			_requestedState = null;
 			_requestedReset = true;
 			_created = false;
+			
+			// inform the subsequent init code to use GPU for rendering.
+			_useGPU = UseGPU;
+			
 			addEventListener(Event.ADDED_TO_STAGE, create);
 		}
 		
@@ -549,9 +558,8 @@ package flixel
 				createFocusScreen();
 			}
 			
-			// TODO: add docs
-			// TODO: init render based on Class coming from FlxGame constructor
-			_render = new FlxGenome2DRender();
+			// Creates and init the render that will be used to draw things into the screen.
+			_render = _useGPU ? new FlxGenome2DRender() : new FlxBlittingRender();
 			_render.init(this, onEnterFrame);
 		}
 		

--- a/src/flixel/FlxGame.as
+++ b/src/flixel/FlxGame.as
@@ -499,7 +499,7 @@ package flixel
 		{
 			var mark:uint = getTimer();
 			FlxG.lockCameras();
-			//_state.draw();
+			_state.draw();
 			FlxG.signals.postDraw.dispatch();
 			FlxG.unlockCameras();
 			if(_debuggerUp)
@@ -550,11 +550,10 @@ package flixel
 				createFocusScreen();
 			}
 			
+			// TODO: add docs
 			// TODO: init render based on Class coming from FlxGame constructor
-			_render = new FlxGenome2DRender(this, function():void {			
-				//Finally, set up an event for the actual game loop stuff.
-				addEventListener(Event.ENTER_FRAME, onEnterFrame);
-			});
+			_render = new FlxGenome2DRender();
+			_render.init(this, onEnterFrame);
 		}
 		
 		/**

--- a/src/flixel/FlxGame.as
+++ b/src/flixel/FlxGame.as
@@ -151,7 +151,7 @@ package flixel
 		 * @param	GameFramerate	How frequently the game should update (default is 60 times per second).
 		 * @param	FlashFramerate	Sets the actual display framerate for Flash player (default is 30 times per second).
 		 * @param	UseSystemCursor	Whether to use the default OS mouse pointer, or to use custom flixel ones.
-		 * @param	UseGPU			Whether to use hardware acceleration for rendering (with Genome2D). Default is <code>false</code> (meaning that flixel must use blitting to render things).
+		 * @param	UseGPU			Whether to use hardware acceleration for rendering (with Genome2D). Default is <code>false</code> (meaning that flixel will use blitting/CPU to draw things).
 		 */
 		public function FlxGame(GameSizeX:uint,GameSizeY:uint,InitialState:Class,Zoom:Number=1,GameFramerate:uint=60,FlashFramerate:uint=30,UseSystemCursor:Boolean=false,UseGPU:Boolean=false)
 		{

--- a/src/flixel/FlxGame.as
+++ b/src/flixel/FlxGame.as
@@ -507,7 +507,7 @@ package flixel
 		protected function draw():void
 		{
 			var mark:uint = getTimer();
-			_render.draw(_state);
+			_render.step(_state);
 			FlxG.signals.postDraw.dispatch();
 
 			if(_debuggerUp)

--- a/src/flixel/FlxGame.as
+++ b/src/flixel/FlxGame.as
@@ -18,6 +18,11 @@ package flixel
 	import flixel.util.FlxMath;
 	import flixel.system.FlxSave;
 	import flixel.system.debug.FlxDebugger;
+	
+	// TODO: clean this up
+	import flixel.system.render.blitting.FlxBlittingRender;
+	import flixel.system.render.FlxRender;
+	import flixel.system.render.genome2d.FlxGenome2DRender;
 
 	/**
 	 * FlxGame is the heart of all flixel games, and contains a bunch of basic game loops and things.
@@ -50,6 +55,10 @@ package flixel
 		 */
 		public var forceDebugger:Boolean;
 
+		/**
+		 * TODO: add docs about render
+		 */
+		protected var _render:FlxRender;
 		/**
 		 * Current game state.
 		 */
@@ -167,7 +176,7 @@ package flixel
 			_requestedState = null;
 			_requestedReset = true;
 			_created = false;
-			addEventListener(Event.ENTER_FRAME, create);
+			addEventListener(Event.ADDED_TO_STAGE, create);
 		}
 		
 		/**
@@ -490,7 +499,7 @@ package flixel
 		{
 			var mark:uint = getTimer();
 			FlxG.lockCameras();
-			_state.draw();
+			//_state.draw();
 			FlxG.signals.postDraw.dispatch();
 			FlxG.unlockCameras();
 			if(_debuggerUp)
@@ -506,7 +515,7 @@ package flixel
 		{
 			if(root == null)
 				return;
-			removeEventListener(Event.ENTER_FRAME, create);
+			removeEventListener(Event.ADDED_TO_STAGE, create);
 			_total = getTimer();
 			
 			//Set up the view window and double buffering
@@ -541,8 +550,11 @@ package flixel
 				createFocusScreen();
 			}
 			
-			//Finally, set up an event for the actual game loop stuff.
-			addEventListener(Event.ENTER_FRAME, onEnterFrame);
+			// TODO: init render based on Class coming from FlxGame constructor
+			_render = new FlxGenome2DRender(this, function():void {			
+				//Finally, set up an event for the actual game loop stuff.
+				addEventListener(Event.ENTER_FRAME, onEnterFrame);
+			});
 		}
 		
 		/**

--- a/src/flixel/FlxGame.as
+++ b/src/flixel/FlxGame.as
@@ -498,10 +498,9 @@ package flixel
 		protected function draw():void
 		{
 			var mark:uint = getTimer();
-			FlxG.lockCameras();
-			_state.draw();
+			_render.draw(_state);
 			FlxG.signals.postDraw.dispatch();
-			FlxG.unlockCameras();
+
 			if(_debuggerUp)
 				_debugger.perf.flixelDraw(getTimer()-mark);
 		}

--- a/src/flixel/FlxGroup.as
+++ b/src/flixel/FlxGroup.as
@@ -126,7 +126,7 @@ package flixel
 			while(i < length)
 			{
 				basic = members[i++] as FlxBasic;
-				if((basic != null) && basic.exists && basic.visible)
+				if((basic != null) && basic.exists && basic.visible && (basic.cameras == null || basic.cameras.indexOf(Camera) != -1))
 					basic.draw(Camera);
 			}
 		}

--- a/src/flixel/FlxGroup.as
+++ b/src/flixel/FlxGroup.as
@@ -116,8 +116,10 @@ package flixel
 		
 		/**
 		 * Automatically goes through and calls render on everything you added.
+		 * 
+		 * @param	Camera	Which camera to draw the visuals to.
 		 */
-		override public function draw():void
+		override public function draw(Camera:FlxCamera):void
 		{
 			var basic:FlxBasic;
 			var i:uint = 0;
@@ -125,7 +127,7 @@ package flixel
 			{
 				basic = members[i++] as FlxBasic;
 				if((basic != null) && basic.exists && basic.visible)
-					basic.draw();
+					basic.draw(Camera);
 			}
 		}
 		

--- a/src/flixel/FlxObject.as
+++ b/src/flixel/FlxObject.as
@@ -325,7 +325,6 @@ package flixel
 			_point = null;
 			_rect = null;
 			last = null;
-			cameras = null;
 			if(path != null)
 				path.destroy();
 			path = null;
@@ -403,23 +402,16 @@ package flixel
 		
 		/**
 		 * Rarely called, and in this case just increments the visible objects count and calls <code>drawDebug()</code> if necessary.
+		 * 
+		 * @param	Camera	Which camera to draw the debug visuals to.
 		 */
-		override public function draw():void
+		override public function draw(Camera:FlxCamera):void
 		{
-			if(cameras == null)
-				cameras = FlxG.cameras;
-			var camera:FlxCamera;
-			var i:uint = 0;
-			var l:uint = cameras.length;
-			while(i < l)
-			{
-				camera = cameras[i++];
-				if(!onScreen(camera))
-					continue;
-				_VISIBLECOUNT++;
-				if(FlxG.visualDebug && !ignoreDrawDebug)
-					drawDebug(camera);
-			}
+			if(!onScreen(Camera))
+				return;
+			_VISIBLECOUNT++;
+			if(FlxG.visualDebug && !ignoreDrawDebug)
+				drawDebug(Camera);
 		}
 		
 		/**

--- a/src/flixel/FlxObject.as
+++ b/src/flixel/FlxObject.as
@@ -464,7 +464,7 @@ package flixel
 			gfx.lineTo(boundingBoxX,boundingBoxY);
 			
 			//draw graphics shape to camera buffer
-			FlxG.render.drawToBuffer(Camera, FlxG.flashGfxSprite);
+			FlxG.render.drawToBuffer(Camera, null, FlxG.flashGfxSprite, null);
 		}
 		
 		/**

--- a/src/flixel/FlxObject.as
+++ b/src/flixel/FlxObject.as
@@ -456,7 +456,7 @@ package flixel
 			gfx.lineTo(boundingBoxX,boundingBoxY);
 			
 			//draw graphics shape to camera buffer
-			FlxG.render.drawToBuffer(Camera, null, FlxG.flashGfxSprite, null);
+			FlxG.render.drawDebug(Camera, FlxG.flashGfxSprite);
 		}
 		
 		/**

--- a/src/flixel/FlxObject.as
+++ b/src/flixel/FlxObject.as
@@ -464,7 +464,7 @@ package flixel
 			gfx.lineTo(boundingBoxX,boundingBoxY);
 			
 			//draw graphics shape to camera buffer
-			Camera.buffer.draw(FlxG.flashGfxSprite);
+			FlxG.render.drawToBuffer(Camera, FlxG.flashGfxSprite);
 		}
 		
 		/**

--- a/src/flixel/FlxSprite.as
+++ b/src/flixel/FlxSprite.as
@@ -480,7 +480,7 @@ package flixel
 			{
 				_flashPoint.x = _point.x;
 				_flashPoint.y = _point.y;
-				FlxG.render.copyPixelsToBuffer(Camera,texture,framePixels,_flashRect,_flashPoint,null,null,true);
+				FlxG.render.copyPixels(Camera,texture,framePixels,_flashRect,_flashPoint,null,null,true);
 			}
 			else //Advanced render
 			{
@@ -490,7 +490,7 @@ package flixel
 				if((angle != 0) && (_bakedRotation <= 0))
 					_matrix.rotate(angle * 0.017453293);
 				_matrix.translate(_point.x+origin.x,_point.y+origin.y);
-				FlxG.render.drawToBuffer(Camera,texture,framePixels,_flashRect,_matrix,null,blend,null,antialiasing);
+				FlxG.render.draw(Camera,texture,framePixels,_flashRect,_matrix,null,blend,null,antialiasing);
 			}
 			
 			_VISIBLECOUNT++;

--- a/src/flixel/FlxSprite.as
+++ b/src/flixel/FlxSprite.as
@@ -201,7 +201,6 @@ package flixel
 			_color = 0x00ffffff;
 			blend = null;
 			antialiasing = false;
-			cameras = null;
 			
 			finished = false;
 			_facing = RIGHT;
@@ -455,8 +454,10 @@ package flixel
 		
 		/**
 		 * Called by game loop, updates then blits or renders current frame of animation to the screen
+		 * 
+		 * @param	Camera	The camera where the object will draw itself to.
 		 */
-		override public function draw():void
+		override public function draw(Camera:FlxCamera):void
 		{
 			if(_flickerTimer != 0)
 			{
@@ -468,42 +469,33 @@ package flixel
 			if(dirty)	//rarely 
 				calcFrame();
 			
-			if(cameras == null)
-				cameras = FlxG.cameras;
-			var camera:FlxCamera;
-			var i:uint = 0;
-			var l:uint = cameras.length;
-			while(i < l)
+			if(!onScreen(Camera))
+				return;
+			_point.x = x - int(Camera.scroll.x*scrollFactor.x) - offset.x;
+			_point.y = y - int(Camera.scroll.y*scrollFactor.y) - offset.y;
+			_point.x += (_point.x > 0)?0.0000001:-0.0000001;
+			_point.y += (_point.y > 0)?0.0000001:-0.0000001;
+			
+			if(isSimpleRender())
 			{
-				camera = cameras[i++];
-				if(!onScreen(camera))
-					continue;
-				_point.x = x - int(camera.scroll.x*scrollFactor.x) - offset.x;
-				_point.y = y - int(camera.scroll.y*scrollFactor.y) - offset.y;
-				_point.x += (_point.x > 0)?0.0000001:-0.0000001;
-				_point.y += (_point.y > 0)?0.0000001:-0.0000001;
-				
-				if(isSimpleRender())
-				{
-					_flashPoint.x = _point.x;
-					_flashPoint.y = _point.y;
-					FlxG.render.copyPixelsToBuffer(camera,texture,framePixels,_flashRect,_flashPoint,null,null,true);
-				}
-				else //Advanced render
-				{
-					_matrix.identity();
-					_matrix.translate(-origin.x,-origin.y);
-					_matrix.scale(scale.x,scale.y);
-					if((angle != 0) && (_bakedRotation <= 0))
-						_matrix.rotate(angle * 0.017453293);
-					_matrix.translate(_point.x+origin.x,_point.y+origin.y);
-					FlxG.render.drawToBuffer(camera,texture,framePixels,_flashRect,_matrix,null,blend,null,antialiasing);
-				}
-				
-				_VISIBLECOUNT++;
-				if(FlxG.visualDebug && !ignoreDrawDebug)
-					drawDebug(camera);
+				_flashPoint.x = _point.x;
+				_flashPoint.y = _point.y;
+				FlxG.render.copyPixelsToBuffer(Camera,texture,framePixels,_flashRect,_flashPoint,null,null,true);
 			}
+			else //Advanced render
+			{
+				_matrix.identity();
+				_matrix.translate(-origin.x,-origin.y);
+				_matrix.scale(scale.x,scale.y);
+				if((angle != 0) && (_bakedRotation <= 0))
+					_matrix.rotate(angle * 0.017453293);
+				_matrix.translate(_point.x+origin.x,_point.y+origin.y);
+				FlxG.render.drawToBuffer(Camera,texture,framePixels,_flashRect,_matrix,null,blend,null,antialiasing);
+			}
+			
+			_VISIBLECOUNT++;
+			if(FlxG.visualDebug && !ignoreDrawDebug)
+				drawDebug(Camera);
 		}
 		
 		/**

--- a/src/flixel/FlxSprite.as
+++ b/src/flixel/FlxSprite.as
@@ -472,7 +472,7 @@ package flixel
 				{
 					_flashPoint.x = _point.x;
 					_flashPoint.y = _point.y;
-					camera.buffer.copyPixels(framePixels,_flashRect,_flashPoint,null,null,true);
+					FlxG.render.copyPixelsToBuffer(camera,framePixels,_flashRect,_flashPoint,null,null,true);
 				}
 				else //Advanced render
 				{
@@ -482,7 +482,7 @@ package flixel
 					if((angle != 0) && (_bakedRotation <= 0))
 						_matrix.rotate(angle * 0.017453293);
 					_matrix.translate(_point.x+origin.x,_point.y+origin.y);
-					camera.buffer.draw(framePixels,_matrix,null,blend,null,antialiasing);
+					FlxG.render.drawToBuffer(camera,framePixels,_matrix,null,blend,null,antialiasing);
 				}
 				
 				_VISIBLECOUNT++;

--- a/src/flixel/FlxSprite.as
+++ b/src/flixel/FlxSprite.as
@@ -478,7 +478,7 @@ package flixel
 			{
 				_flashPoint.x = _point.x;
 				_flashPoint.y = _point.y;
-				FlxG.render.copyPixels(Camera,texture.gpuData,framePixels,_flashRect,_flashPoint,null,null,true);
+				FlxG.render.copyPixels(Camera,texture,framePixels,_flashRect,_flashPoint,null,null,true);
 			}
 			else //Advanced render
 			{
@@ -491,7 +491,7 @@ package flixel
 				if((angle != 0) && (_bakedRotation <= 0))
 					_matrix.rotate(angle * 0.017453293);
 				_matrix.translate(_point.x+origin.x,_point.y+origin.y);
-				FlxG.render.draw(Camera,texture.gpuData,framePixels,_flashRect,_matrix,null,blend,null,antialiasing);
+				FlxG.render.draw(Camera,texture,framePixels,_flashRect,_matrix,null,blend,null,antialiasing);
 			}
 			
 			_VISIBLECOUNT++;

--- a/src/flixel/FlxSprite.as
+++ b/src/flixel/FlxSprite.as
@@ -198,6 +198,7 @@ package flixel
 			_color = 0x00ffffff;
 			blend = null;
 			antialiasing = false;
+			cameras = null;
 			
 			finished = false;
 			_facing = RIGHT;

--- a/src/flixel/FlxSprite.as
+++ b/src/flixel/FlxSprite.as
@@ -483,7 +483,10 @@ package flixel
 			else //Advanced render
 			{
 				_matrix.identity();
-				_matrix.translate(-origin.x,-origin.y);
+				if (FlxG.render.isBlitting())
+				{
+					_matrix.translate( -origin.x, -origin.y);
+				}
 				_matrix.scale(scale.x,scale.y);
 				if((angle != 0) && (_bakedRotation <= 0))
 					_matrix.rotate(angle * 0.017453293);

--- a/src/flixel/system/debug/Perf.as
+++ b/src/flixel/system/debug/Perf.as
@@ -44,7 +44,7 @@ package flixel.system.debug
 		public function Perf(Title:String, Width:Number, Height:Number, Resizable:Boolean=true, Bounds:Rectangle=null, BGColor:uint=0x7f7f7f7f, TopColor:uint=0x7f000000)
 		{
 			super(Title, Width, Height, Resizable, Bounds, BGColor, TopColor);
-			resize(90,66);
+			resize(90,112);
 			
 			_lastTime = 0;
 			_updateTimer = 0;
@@ -140,8 +140,11 @@ package flixel.system.debug
 					visibleCount += _visibleObject[i++];
 				visibleCount /= _visibleObjectMarker;
 
-				output += "D:" + visibleCount + " " + uint(drawTime/_flixelDrawMarker) + "ms";
+				output += "D:" + visibleCount + " " + uint(drawTime/_flixelDrawMarker) + "ms\n\n";
 
+				// Append the render info
+				output += "Render:" + FlxG.render.info + "\n";
+				
 				_text.text = output;
 
 				_flixelUpdateMarker = 0;

--- a/src/flixel/system/render/FlxRender.as
+++ b/src/flixel/system/render/FlxRender.as
@@ -52,42 +52,40 @@ package flixel.system.render
 		function step(State:FlxState):void;
 		
 		/**
-		 * Provides a fast routine to perform pixel copying between the source and the screen with no stretching,
-		 * rotation, or color effects. This method copies a rectangular area of a source image to a
-		 * rectangular area of the same size at the destination point of the informed destination.
-		 * 
-		 * This method is an imitation of <code>BitmapData#copyPixels()</code>.
+		 * Draw the source object into the screen with no stretching, rotation, or color effects. 
+		 * This method renders a rectangular area of a source image to a rectangular area of the same size
+		 * at the destination point of the informed destination.
 		 * 
 		 * @param	Camera				The camera that is being rendered to the screen at the moment.
-		 * @param	sourceTexture		TODO: encapsulate it under FlxTexture.
-		 * @param	sourceBitmapData	TODO: encapsulate it under FlxTexture.
-		 * @param	sourceRect			A rectangle that defines the area of the source image to use as input.
-		 * @param	destPoint			The destination point that represents the upper-left corner of the rectangular area where the new pixels are placed.
-		 * @param	alphaBitmapData		A secondary, alpha BitmapData object source.
-		 * @param	alphaPoint			The point in the alpha BitmapData object source that corresponds to the upper-left corner of the sourceRect parameter.
-		 * @param	mergeAlpha			To use the alpha channel, set the value to true. To copy pixels with no alpha channel, set the value to <code>false</code>
+		 * @param	SourceTexture		TODO: encapsulate it under FlxTexture.
+		 * @param	SourceBitmapData	TODO: encapsulate it under FlxTexture.
+		 * @param	SourceRect			A rectangle that defines the area of the source image to use as input.
+		 * @param	DestPoint			The destination point that represents the upper-left corner of the rectangular area where the new pixels are placed.
+		 * @param	AlphaBitmapData		A secondary, alpha BitmapData object source.
+		 * @param	AlphaPoint			The point in the alpha BitmapData object source that corresponds to the upper-left corner of the SourceRect parameter.
+		 * @param	MergeAlpha			To use the alpha channel, set the value to true. To copy pixels with no alpha channel, set the value to <code>false</code>
 		 */
-		function copyPixels(Camera:FlxCamera, sourceTexture:GTexture ,sourceBitmapData:BitmapData, sourceRect:Rectangle, destPoint:Point, alphaBitmapData:BitmapData = null, alphaPoint:Point = null, mergeAlpha:Boolean = false):void;
+		function copyPixels(Camera:FlxCamera, SourceTexture:GTexture, SourceBitmapData:BitmapData, SourceRect:Rectangle, DestPoint:Point, AlphaBitmapData:BitmapData = null, AlphaPoint:Point = null, MergeAlpha:Boolean = false):void;
 		
 		/**
-		 * Draws the source display object onto the screen using transformations. You can specify matrix, colorTransform, 
-		 * blendMode, and a destination clipRect parameter to control how the rendering performs.
+		 * Draws the source display object into the screen using transformations. You can specify matrix, colorTransform, 
+		 * blendMode, and a destination ClipRect parameter to control how the rendering performs.
 		 * Optionally, you can specify whether the bitmap should be smoothed when scaled (this works only if the source object
 		 * is a BitmapData object).
 		 * 
 		 * This method is an imitation of <code>BitmapData#draw()</code>.
 		 * 
 		 * @param	Camera				The camera that is being rendered to the screen at the moment.
-		 * @param	sourceTexture		TODO: encapsulate it under FlxTexture.
-		 * @param	source				TODO: encapsulate it under FlxTexture.
-		 * @param	sourceRect			A rectangle that defines the area of the source image to use as input.
-		 * @param	matrix				A Matrix object used to scale, rotate, or translate the coordinates of the input. It's <code>null</code> by default, meaning no transformation will be applied.
-		 * @param	colorTransform		A ColorTransform object used to adjust the color values of the input during rendering. It's <code>null</code> by default, meaning no transformation will be applied.
-		 * @param	blendMode			A string value, from the <code>flash.display.BlendMode</code> class, specifying the blend mode to be applied during rendering.
-		 * @param	clipRect			A Rectangle object that defines the area of the source object to draw. If <code>null</code> is provided (default), no clipping occurs and the entire source object is drawn.
-		 * @param	smoothing			A Boolean value that determines whether a the source object is smoothed when scaled or rotated, due to a scaling or rotation in the matrix parameter.
+		 * @param	SourceTexture		TODO: encapsulate it under FlxTexture.
+		 * @param	Source				TODO: encapsulate it under FlxTexture.
+		 * @param	SourceRect			A rectangle that defines the area of the source image to use as input.
+		 * @param	TransMatrix			A Matrix object used to scale, rotate, or translate the coordinates of the input. It's <code>null</code> by default, meaning no transformation will be applied.
+		 * @param	ColorTrans			A ColorTransform object used to adjust the color values of the input during rendering. It's <code>null</code> by default, meaning no transformation will be applied.
+		 * @param	BlendMode			A string value, from the <code>flash.display.BlendMode</code> class, specifying the blend mode to be applied during rendering.
+		 * @param	ClipRect			A Rectangle object that defines the area of the source object to draw. If <code>null</code> is provided (default), no clipping occurs and the entire source object is drawn.
+		 * @param	Smoothing			A Boolean value that determines whether a the source object is smoothed when scaled or rotated, due to a scaling or rotation in the Matrix parameter.
 		 */
-		function draw(Camera:FlxCamera, sourceTexture:GTexture, source:IBitmapDrawable, sourceRect:Rectangle, matrix:Matrix = null, colorTransform:ColorTransform = null, blendMode:String = null, clipRect:Rectangle = null, smoothing:Boolean = false):void;
+		function draw(Camera:FlxCamera, SourceTexture:GTexture, Source:IBitmapDrawable, SourceRect:Rectangle, TransMatrix:Matrix = null, ColorTrans:ColorTransform = null, BlendMode:String = null, ClipRect:Rectangle = null, Smoothing:Boolean = false):void;
 		
 		/**
 		 * Draws generic graphics to the screen using a blitting debug buffer. Highly changing graphics, such as debug lines, cannot be uploaed to
@@ -97,6 +95,6 @@ package flixel.system.render
 		 * @param	Camera				The camera that is being rendered to the screen at the moment.
 		 * @param	source				The display object or BitmapData object to draw to the BitmapData object.
 		 */
-		function drawDebug(Camera:FlxCamera, source:IBitmapDrawable):void;
+		function drawDebug(Camera:FlxCamera, Source:IBitmapDrawable):void;
 	}
 }

--- a/src/flixel/system/render/FlxRender.as
+++ b/src/flixel/system/render/FlxRender.as
@@ -1,5 +1,6 @@
 package flixel.system.render 
 {
+	import com.genome2d.textures.GTexture;
 	import flash.display.BitmapData;
 	import flash.display.IBitmapDrawable;
 	import flash.geom.ColorTransform;
@@ -36,6 +37,7 @@ package flixel.system.render
 		 * TODO: find a better name for this method.
 		 * 
 		 * @param	Camera
+		 * @param	sourceTexture
 		 * @param	sourceBitmapData
 		 * @param	sourceRect
 		 * @param	destPoint
@@ -43,20 +45,22 @@ package flixel.system.render
 		 * @param	alphaPoint
 		 * @param	mergeAlpha
 		 */
-		function copyPixelsToBuffer(Camera:FlxCamera, sourceBitmapData:BitmapData, sourceRect:Rectangle, destPoint:Point, alphaBitmapData:BitmapData = null, alphaPoint:Point = null, mergeAlpha:Boolean = false):void;
+		function copyPixelsToBuffer(Camera:FlxCamera, sourceTexture:GTexture ,sourceBitmapData:BitmapData, sourceRect:Rectangle, destPoint:Point, alphaBitmapData:BitmapData = null, alphaPoint:Point = null, mergeAlpha:Boolean = false):void;
 		
 		/**
 		 * TODO: Render: add docs.
 		 * TODO: find a better name for this method.
 		 * 
 		 * @param	Camera
+		 * @param	sourceTexture
 		 * @param	source
+		 * @param	sourceRect
 		 * @param	matrix
 		 * @param	colorTransform
 		 * @param	blendMode
 		 * @param	clipRect
 		 * @param	smoothing
 		 */
-		function drawToBuffer(Camera:FlxCamera, source:IBitmapDrawable, matrix:Matrix = null, colorTransform:ColorTransform = null, blendMode:String = null, clipRect:Rectangle = null, smoothing:Boolean = false):void;
+		function drawToBuffer(Camera:FlxCamera, sourceTexture:GTexture, source:IBitmapDrawable, sourceRect:Rectangle, matrix:Matrix = null, colorTransform:ColorTransform = null, blendMode:String = null, clipRect:Rectangle = null, smoothing:Boolean = false):void;
 	}
 }

--- a/src/flixel/system/render/FlxRender.as
+++ b/src/flixel/system/render/FlxRender.as
@@ -1,0 +1,15 @@
+package flixel.system.render 
+{
+	import flixel.FlxGame;
+	
+	/**
+	 * TODO: add docs
+	 * @author Dovyski
+	 */
+	public class FlxRender 
+	{
+		public function FlxRender(Game:FlxGame, StartGameCallback:Function) 
+		{
+		}
+	}
+}

--- a/src/flixel/system/render/FlxRender.as
+++ b/src/flixel/system/render/FlxRender.as
@@ -43,41 +43,60 @@ package flixel.system.render
 		function isBlitting():Boolean;
 		
 		/**
-		 * TODO: add docs
+		 * Performs a graphic step, rendering all elements into the screen. Flixel will invoke this method after
+		 * it has updated all game entities. This method *should not* be invoked directly since Flixel will do
+		 * it automatically at the right time.
 		 * 
-		 * @param	State
+		 * @param	State	The state whose elements will be rendered into the screen.
 		 */
-		function draw(State:FlxState):void;
+		function step(State:FlxState):void;
 		
 		/**
-		 * TODO: Render: add docs.
-		 * TODO: find a better name for this method.
+		 * Provides a fast routine to perform pixel copying between the source and the screen with no stretching,
+		 * rotation, or color effects. This method copies a rectangular area of a source image to a
+		 * rectangular area of the same size at the destination point of the informed destination.
 		 * 
-		 * @param	Camera
-		 * @param	sourceTexture
-		 * @param	sourceBitmapData
-		 * @param	sourceRect
-		 * @param	destPoint
-		 * @param	alphaBitmapData
-		 * @param	alphaPoint
-		 * @param	mergeAlpha
+		 * This method is an imitation of <code>BitmapData#copyPixels()</code>.
+		 * 
+		 * @param	Camera				The camera that is being rendered to the screen at the moment.
+		 * @param	sourceTexture		TODO: encapsulate it under FlxTexture.
+		 * @param	sourceBitmapData	TODO: encapsulate it under FlxTexture.
+		 * @param	sourceRect			A rectangle that defines the area of the source image to use as input.
+		 * @param	destPoint			The destination point that represents the upper-left corner of the rectangular area where the new pixels are placed.
+		 * @param	alphaBitmapData		A secondary, alpha BitmapData object source.
+		 * @param	alphaPoint			The point in the alpha BitmapData object source that corresponds to the upper-left corner of the sourceRect parameter.
+		 * @param	mergeAlpha			To use the alpha channel, set the value to true. To copy pixels with no alpha channel, set the value to <code>false</code>
 		 */
-		function copyPixelsToBuffer(Camera:FlxCamera, sourceTexture:GTexture ,sourceBitmapData:BitmapData, sourceRect:Rectangle, destPoint:Point, alphaBitmapData:BitmapData = null, alphaPoint:Point = null, mergeAlpha:Boolean = false):void;
+		function copyPixels(Camera:FlxCamera, sourceTexture:GTexture ,sourceBitmapData:BitmapData, sourceRect:Rectangle, destPoint:Point, alphaBitmapData:BitmapData = null, alphaPoint:Point = null, mergeAlpha:Boolean = false):void;
 		
 		/**
-		 * TODO: Render: add docs.
-		 * TODO: find a better name for this method.
+		 * Draws the source display object onto the screen using transformations. You can specify matrix, colorTransform, 
+		 * blendMode, and a destination clipRect parameter to control how the rendering performs.
+		 * Optionally, you can specify whether the bitmap should be smoothed when scaled (this works only if the source object
+		 * is a BitmapData object).
 		 * 
-		 * @param	Camera
-		 * @param	sourceTexture
-		 * @param	source
-		 * @param	sourceRect
-		 * @param	matrix
-		 * @param	colorTransform
-		 * @param	blendMode
-		 * @param	clipRect
-		 * @param	smoothing
+		 * This method is an imitation of <code>BitmapData#draw()</code>.
+		 * 
+		 * @param	Camera				The camera that is being rendered to the screen at the moment.
+		 * @param	sourceTexture		TODO: encapsulate it under FlxTexture.
+		 * @param	source				TODO: encapsulate it under FlxTexture.
+		 * @param	sourceRect			A rectangle that defines the area of the source image to use as input.
+		 * @param	matrix				A Matrix object used to scale, rotate, or translate the coordinates of the input. It's <code>null</code> by default, meaning no transformation will be applied.
+		 * @param	colorTransform		A ColorTransform object used to adjust the color values of the input during rendering. It's <code>null</code> by default, meaning no transformation will be applied.
+		 * @param	blendMode			A string value, from the <code>flash.display.BlendMode</code> class, specifying the blend mode to be applied during rendering.
+		 * @param	clipRect			A Rectangle object that defines the area of the source object to draw. If <code>null</code> is provided (default), no clipping occurs and the entire source object is drawn.
+		 * @param	smoothing			A Boolean value that determines whether a the source object is smoothed when scaled or rotated, due to a scaling or rotation in the matrix parameter.
 		 */
-		function drawToBuffer(Camera:FlxCamera, sourceTexture:GTexture, source:IBitmapDrawable, sourceRect:Rectangle, matrix:Matrix = null, colorTransform:ColorTransform = null, blendMode:String = null, clipRect:Rectangle = null, smoothing:Boolean = false):void;
+		function draw(Camera:FlxCamera, sourceTexture:GTexture, source:IBitmapDrawable, sourceRect:Rectangle, matrix:Matrix = null, colorTransform:ColorTransform = null, blendMode:String = null, clipRect:Rectangle = null, smoothing:Boolean = false):void;
+		
+		/**
+		 * Draws generic graphics to the screen using a blitting debug buffer. Highly changing graphics, such as debug lines, cannot be uploaed to
+		 * the GPU every frame, so the render provides this method that renders a source object to a special buffer using blitting.
+		 * This method should be used when performance is not a concern, e.g. when debug overlays are being rendered.
+		 * 
+		 * @param	Camera				The camera that is being rendered to the screen at the moment.
+		 * @param	source				The display object or BitmapData object to draw to the BitmapData object.
+		 */
+		function drawDebug(Camera:FlxCamera, source:IBitmapDrawable):void;
 	}
 }

--- a/src/flixel/system/render/FlxRender.as
+++ b/src/flixel/system/render/FlxRender.as
@@ -12,18 +12,35 @@ package flixel.system.render
 	import flixel.FlxState;
 	
 	/**
-	 * TODO: add docs
+	 * Interface that defines how all renders must be structured. When Flixel has updated the current game frame, it will
+	 * invoke the render's drawing method to display everything on the screen.
+	 * 
 	 * @author Dovyski
 	 */
 	public interface FlxRender 
 	{
 		/**
-		 * TODO: add docs
+		 * Initializes the render.
 		 * 
-		 * @param	Game
-		 * @param	StartGameCallback
+		 * @param	Game				A reference to the game object.
+		 * @param	StartGameCallback	A callback function in the form <code>callback(e:FlashEvent=null)</code> that will be invoked by the render whenever it is ready to process the next frame.
 		 */
 		function init(Game:FlxGame, UpdateCallback:Function):void;
+		
+		/**
+		 * Returns a few information about the render. That info displayed at the bottom of the performance
+		 * overlay when debug information is active.
+		 * 
+		 * @return A string containing information about the render, e.g. "Blitting" or "GPU (Genome2D)".
+		 */
+		function get info():String;
+		
+		/**
+		 * Tells if the render is working with blitting (copying pixels using BitmapData) or not.
+		 * 
+		 * @return <code>true</code> true if blitting is being used to display things into the screen, or <code>false</code> otherwise (using GPU).
+		 */
+		function isBlitting():Boolean;
 		
 		/**
 		 * TODO: add docs

--- a/src/flixel/system/render/FlxRender.as
+++ b/src/flixel/system/render/FlxRender.as
@@ -1,6 +1,7 @@
 package flixel.system.render 
 {
 	import flixel.FlxGame;
+	import flixel.FlxState;
 	
 	/**
 	 * TODO: add docs
@@ -15,5 +16,12 @@ package flixel.system.render
 		 * @param	StartGameCallback
 		 */
 		function init(Game:FlxGame, UpdateCallback:Function):void;
+		
+		/**
+		 * TODO: add docs
+		 * 
+		 * @param	State
+		 */
+		function draw(State:FlxState):void;
 	}
 }

--- a/src/flixel/system/render/FlxRender.as
+++ b/src/flixel/system/render/FlxRender.as
@@ -6,10 +6,14 @@ package flixel.system.render
 	 * TODO: add docs
 	 * @author Dovyski
 	 */
-	public class FlxRender 
+	public interface FlxRender 
 	{
-		public function FlxRender(Game:FlxGame, StartGameCallback:Function) 
-		{
-		}
+		/**
+		 * TODO: add docs
+		 * 
+		 * @param	Game
+		 * @param	StartGameCallback
+		 */
+		function init(Game:FlxGame, UpdateCallback:Function):void;
 	}
 }

--- a/src/flixel/system/render/FlxRender.as
+++ b/src/flixel/system/render/FlxRender.as
@@ -1,5 +1,12 @@
 package flixel.system.render 
 {
+	import flash.display.BitmapData;
+	import flash.display.IBitmapDrawable;
+	import flash.geom.ColorTransform;
+	import flash.geom.Matrix;
+	import flash.geom.Point;
+	import flash.geom.Rectangle;
+	import flixel.FlxCamera;
 	import flixel.FlxGame;
 	import flixel.FlxState;
 	
@@ -23,5 +30,33 @@ package flixel.system.render
 		 * @param	State
 		 */
 		function draw(State:FlxState):void;
+		
+		/**
+		 * TODO: Render: add docs.
+		 * TODO: find a better name for this method.
+		 * 
+		 * @param	Camera
+		 * @param	sourceBitmapData
+		 * @param	sourceRect
+		 * @param	destPoint
+		 * @param	alphaBitmapData
+		 * @param	alphaPoint
+		 * @param	mergeAlpha
+		 */
+		function copyPixelsToBuffer(Camera:FlxCamera, sourceBitmapData:BitmapData, sourceRect:Rectangle, destPoint:Point, alphaBitmapData:BitmapData = null, alphaPoint:Point = null, mergeAlpha:Boolean = false):void;
+		
+		/**
+		 * TODO: Render: add docs.
+		 * TODO: find a better name for this method.
+		 * 
+		 * @param	Camera
+		 * @param	source
+		 * @param	matrix
+		 * @param	colorTransform
+		 * @param	blendMode
+		 * @param	clipRect
+		 * @param	smoothing
+		 */
+		function drawToBuffer(Camera:FlxCamera, source:IBitmapDrawable, matrix:Matrix = null, colorTransform:ColorTransform = null, blendMode:String = null, clipRect:Rectangle = null, smoothing:Boolean = false):void;
 	}
 }

--- a/src/flixel/system/render/FlxRender.as
+++ b/src/flixel/system/render/FlxRender.as
@@ -1,6 +1,5 @@
 package flixel.system.render 
 {
-	import com.genome2d.textures.GTexture;
 	import flash.display.BitmapData;
 	import flash.display.IBitmapDrawable;
 	import flash.geom.ColorTransform;
@@ -57,15 +56,15 @@ package flixel.system.render
 		 * at the destination point of the informed destination.
 		 * 
 		 * @param	Camera				The camera that is being rendered to the screen at the moment.
-		 * @param	SourceTexture		TODO: encapsulate it under FlxTexture.
-		 * @param	SourceBitmapData	TODO: encapsulate it under FlxTexture.
+		 * @param	SourceTexture		A GPU texture representing the graphic to be rendered.
+		 * @param	SourceBitmapData	A bitmapData representing the graphic to be rendered.
 		 * @param	SourceRect			A rectangle that defines the area of the source image to use as input.
 		 * @param	DestPoint			The destination point that represents the upper-left corner of the rectangular area where the new pixels are placed.
 		 * @param	AlphaBitmapData		A secondary, alpha BitmapData object source.
 		 * @param	AlphaPoint			The point in the alpha BitmapData object source that corresponds to the upper-left corner of the SourceRect parameter.
 		 * @param	MergeAlpha			To use the alpha channel, set the value to true. To copy pixels with no alpha channel, set the value to <code>false</code>
 		 */
-		function copyPixels(Camera:FlxCamera, SourceTexture:GTexture, SourceBitmapData:BitmapData, SourceRect:Rectangle, DestPoint:Point, AlphaBitmapData:BitmapData = null, AlphaPoint:Point = null, MergeAlpha:Boolean = false):void;
+		function copyPixels(Camera:FlxCamera, SourceTexture:FlxTexture, SourceBitmapData:BitmapData, SourceRect:Rectangle, DestPoint:Point, AlphaBitmapData:BitmapData = null, AlphaPoint:Point = null, MergeAlpha:Boolean = false):void;
 		
 		/**
 		 * Draws the source display object into the screen using transformations. You can specify matrix, colorTransform, 
@@ -76,8 +75,8 @@ package flixel.system.render
 		 * This method is an imitation of <code>BitmapData#draw()</code>.
 		 * 
 		 * @param	Camera				The camera that is being rendered to the screen at the moment.
-		 * @param	SourceTexture		TODO: encapsulate it under FlxTexture.
-		 * @param	Source				TODO: encapsulate it under FlxTexture.
+		 * @param	SourceTexture		A GPU texture representing the graphic to be rendered.
+		 * @param	Source				A bitmapData representing the graphic to be rendered.
 		 * @param	SourceRect			A rectangle that defines the area of the source image to use as input.
 		 * @param	TransMatrix			A Matrix object used to scale, rotate, or translate the coordinates of the input. It's <code>null</code> by default, meaning no transformation will be applied.
 		 * @param	ColorTrans			A ColorTransform object used to adjust the color values of the input during rendering. It's <code>null</code> by default, meaning no transformation will be applied.
@@ -85,7 +84,7 @@ package flixel.system.render
 		 * @param	ClipRect			A Rectangle object that defines the area of the source object to draw. If <code>null</code> is provided (default), no clipping occurs and the entire source object is drawn.
 		 * @param	Smoothing			A Boolean value that determines whether a the source object is smoothed when scaled or rotated, due to a scaling or rotation in the Matrix parameter.
 		 */
-		function draw(Camera:FlxCamera, SourceTexture:GTexture, Source:IBitmapDrawable, SourceRect:Rectangle, TransMatrix:Matrix = null, ColorTrans:ColorTransform = null, BlendMode:String = null, ClipRect:Rectangle = null, Smoothing:Boolean = false):void;
+		function draw(Camera:FlxCamera, SourceTexture:FlxTexture, Source:IBitmapDrawable, SourceRect:Rectangle, TransMatrix:Matrix = null, ColorTrans:ColorTransform = null, BlendMode:String = null, ClipRect:Rectangle = null, Smoothing:Boolean = false):void;
 		
 		/**
 		 * Draws generic graphics to the screen using a blitting debug buffer. Highly changing graphics, such as debug lines, cannot be uploaed to

--- a/src/flixel/system/render/FlxTexture.as
+++ b/src/flixel/system/render/FlxTexture.as
@@ -37,10 +37,9 @@ package flixel.system.render {
 		
 		protected function uploadBitmapDataToGPU():void
 		{
-			disposeGPUData();
-			
 			if (!FlxG.render.isBlitting())
 			{
+				disposeGPUData();
 				// TODO: Move this texture creation to FlxRender?
 				_gpuData = GTextureFactory.createFromBitmapData("FlxTexture" + Math.random(), _bitmapData);
 			}

--- a/src/flixel/system/render/FlxTexture.as
+++ b/src/flixel/system/render/FlxTexture.as
@@ -31,7 +31,7 @@ package flixel.system.render {
 		{
 			if (Data != null)
 			{
-				setBtmapData(Data);
+				setBitmapData(Data);
 			}
 		}
 		
@@ -78,7 +78,11 @@ package flixel.system.render {
 		public function destroy():void
 		{
 			disposeGPUData();
-			disposeBitmapData();
+			_bitmapData = null;
+			
+			// TODO: call disposeBitmapData() here someday. In order to do that, we must know
+			// if the current bitmapData is not cached by FlxG; if it is, we cannot dispose it
+			// since it might be in use by another sprite.
 		}
 		
 		/**
@@ -144,7 +148,7 @@ package flixel.system.render {
 		 * @param	New				The new bitmapData that will be used for the texture.
 		 * @param	DestroyOldOne	A boolean indicating if the old bitmapData should be destroyed and freed from memory. Default is <code>false</code>.
 		 */
-		public function setBtmapData(New:BitmapData, DestroyOldOne:Boolean = false):void
+		public function setBitmapData(New:BitmapData, DestroyOldOne:Boolean = false):void
 		{
 			if (New == null)
 			{

--- a/src/flixel/system/render/FlxTexture.as
+++ b/src/flixel/system/render/FlxTexture.as
@@ -1,0 +1,173 @@
+package flixel.system.render {
+	import com.genome2d.textures.factories.GTextureFactory;
+	import com.genome2d.textures.GTexture;
+	import flash.display.BitmapData;
+	import flash.geom.Rectangle;
+	import flixel.FlxG;
+	
+	/**
+	 * A class to abstract the creation and manipulation of graphics (in BitmapData or GPU textures). The class will
+	 * work based on the current render, uploading data to the GPU if Flixel is running in GPU mode.
+	 * 
+	 * @author Fernando Bevilacqua
+	 */
+	public class FlxTexture
+	{
+		/**
+		 * The bitmapData of the texture.
+		 */
+		protected var _bitmapData:BitmapData;
+		/**
+		 * A reference to the GPU memory where the texture was uploaded to.
+		 */
+		protected var _gpuData:GTexture;
+		
+		/**
+		 * Constructor.
+		 * 
+		 * @param	Data	A reference to a BitmapData object that will be used to populate the texture.
+		 */
+		public function FlxTexture(Data:BitmapData = null) 
+		{
+			if (Data != null)
+			{
+				setBtmapData(Data);
+			}
+		}
+		
+		protected function uploadBitmapDataToGPU():void
+		{
+			disposeGPUData();
+			
+			if (!FlxG.render.isBlitting())
+			{
+				// TODO: Move this texture creation to FlxRender?
+				_gpuData = GTextureFactory.createFromBitmapData("FlxTexture" + Math.random(), _bitmapData);
+			}
+		}
+		
+		/**
+		 * Frees the GPU memory associated with the texture. It does not
+		 * free the memory occupied by the bitmapData that originated the texture.
+		 */
+		protected function disposeGPUData():void
+		{
+			if (_gpuData != null)
+			{
+				_gpuData.dispose();
+				_gpuData = null;
+			}
+		}
+		
+		/**
+		 * Frees the memory occupied by the bitmapData.
+		 */
+		protected function disposeBitmapData():void
+		{
+			if (_bitmapData != null)
+			{
+				_bitmapData.dispose();
+				_bitmapData = null;
+			}
+		}
+		
+		/**
+		 * Completly destroy the texture, freeing the GPU memory allocated to the
+		 * texture and the bitmapData used to create it.
+		 */
+		public function destroy():void
+		{
+			disposeGPUData();
+			disposeBitmapData();
+		}
+		
+		/**
+		 * Recycles (or creates) a new FlxTexture object with a specified width, height and color.
+		 * If you specify a value for the <code>FillColor</code> parameter, every pixel in the texture
+		 * (and its corresponding bitmap) is set to that color.
+		 * 
+		 * If the object already has an active bitmapData matching the specified parameters, it will be used to create the GPU texture.
+		 * 
+		 * @param	Width		The width of the sprite you want to generate.
+		 * @param	Height		The height of the sprite you want to generate.
+		 * @param	Color		Specifies the color of the generated block in ARGB format. The default value is 0xFFFFFFFF (solid white).
+		 */
+		public function makeGraphic(Width:int, Height:int, Color:uint = 4294967295):void
+		{
+			var regenBitmap:Boolean = true;
+			
+			if (_bitmapData != null)
+			{
+				if (_bitmapData.width == Width && _bitmapData.height == Height)
+				{
+					// The current bitmapData can be re-used to create the new texture.
+					_bitmapData.fillRect(new Rectangle(0, 0, _bitmapData.width, _bitmapData.height), Color);
+					regenBitmap = false;
+				}
+			}
+			
+			if (regenBitmap)
+			{
+				// TODO: there should be a param to tell the function to destroy the old bitmapData.
+				_bitmapData = new BitmapData(Width, Height, false, Color);
+			}
+
+			// Free the current GPU texture and create/upload a new one.
+			uploadBitmapDataToGPU();
+		}
+		
+		/**
+		 * Updates the GPU texture using the bitmapData. This method should be called every time
+		 * the texture's bitmapData is changed outside the FlxTexture class, otherwise the GPU
+		 * texture will remain with the pixels from the old bitmapData.
+		 * 
+		 * IMPORTANT: this method uploads the bitmapData to the GPU, so it drastically impacts performance.
+		 * Don't use it inside a loop, for instance.
+		 */
+		public function markBitmapDataAsDirty():void
+		{
+			uploadBitmapDataToGPU();
+		}
+		
+		/**
+		 * Returns a reference to the bitmap representation of the texture.
+		 */
+		public function get bitmapData():BitmapData
+		{
+			return _bitmapData;
+		}
+		
+		/**
+		 * Sets a new bitmapData. This method uploads the bitmapData to the GPU, so it drastically impacts performance.
+		 * Don't use it inside a loop, for instance.
+		 * 
+		 * @param	New				The new bitmapData that will be used for the texture.
+		 * @param	DestroyOldOne	A boolean indicating if the old bitmapData should be destroyed and freed from memory. Default is <code>false</code>.
+		 */
+		public function setBtmapData(New:BitmapData, DestroyOldOne:Boolean = false):void
+		{
+			if (New == null)
+			{
+				throw new UninitializedError("The new BitmapData cannot be null.");
+			}
+			
+			if (DestroyOldOne)
+			{
+				disposeBitmapData();
+			}
+			
+			_bitmapData = New;
+			uploadBitmapDataToGPU();
+		}
+	
+		/**
+		 * Returns a reference to the GPU memory associated with this texture.
+		 * If the current render is blitting-based, this function will always return <code>null</code>.
+		 */
+		public function get gpuData():GTexture
+		{
+			return _gpuData;
+		}
+	}
+
+}

--- a/src/flixel/system/render/blitting/FlxBlittingRender.as
+++ b/src/flixel/system/render/blitting/FlxBlittingRender.as
@@ -1,0 +1,21 @@
+package flixel.system.render.blitting 
+{
+	import flixel.FlxGame;
+	import flixel.system.render.FlxRender;
+	
+	/**
+	 * TODO: add docs
+	 * @author Dovyski
+	 */
+	public class FlxBlittingRender extends FlxRender
+	{
+		
+		public function FlxBlittingRender(Game:FlxGame, StartGameCallback:Function) 
+		{
+			super(Game, StartGameCallback);
+			
+			// Nothing to init here, just tell Flixel the render is ready to roll!
+			StartGameCallback();
+		}
+	}
+}

--- a/src/flixel/system/render/blitting/FlxBlittingRender.as
+++ b/src/flixel/system/render/blitting/FlxBlittingRender.as
@@ -1,6 +1,5 @@
 package flixel.system.render.blitting 
 {
-	import com.genome2d.textures.GTexture;
 	import flash.display.BitmapData;
 	import flash.display.IBitmapDrawable;
 	import flash.events.Event;
@@ -10,6 +9,7 @@ package flixel.system.render.blitting
 	import flash.geom.Rectangle;
 	import flixel.*;
 	import flixel.system.render.FlxRender;
+	import flixel.system.render.FlxTexture;
 	
 	/**
 	 * A CPU render based on blitting. It uses Bitmaps draw thing into the screen, copying pixels
@@ -90,15 +90,15 @@ package flixel.system.render.blitting
 		 * at the destination point of the informed destination.
 		 * 
 		 * @param	Camera				The camera that is being rendered to the screen at the moment.
-		 * @param	SourceTexture		TODO: encapsulate it under FlxTexture.
-		 * @param	SourceBitmapData	TODO: encapsulate it under FlxTexture.
+		 * @param	SourceTexture		A GPU texture representing the graphic to be rendered.
+		 * @param	SourceBitmapData	A bitmapData representing the graphic to be rendered.
 		 * @param	SourceRect			A rectangle that defines the area of the source image to use as input.
 		 * @param	DestPoint			The destination point that represents the upper-left corner of the rectangular area where the new pixels are placed.
 		 * @param	AlphaBitmapData		A secondary, alpha BitmapData object source.
 		 * @param	AlphaPoint			The point in the alpha BitmapData object source that corresponds to the upper-left corner of the SourceRect parameter.
 		 * @param	MergeAlpha			To use the alpha channel, set the value to true. To copy pixels with no alpha channel, set the value to <code>false</code>
 		 */
-		public function copyPixels(Camera:FlxCamera, SourceTexture:GTexture, SourceBitmapData:BitmapData, SourceRect:Rectangle, DestPoint:Point, AlphaBitmapData:BitmapData = null, AlphaPoint:Point = null, MergeAlpha:Boolean = false):void
+		public function copyPixels(Camera:FlxCamera, SourceTexture:FlxTexture, SourceBitmapData:BitmapData, SourceRect:Rectangle, DestPoint:Point, AlphaBitmapData:BitmapData = null, AlphaPoint:Point = null, MergeAlpha:Boolean = false):void
 		{
 			Camera.buffer.copyPixels(SourceBitmapData, SourceRect, DestPoint, AlphaBitmapData, AlphaPoint, MergeAlpha);
 		}
@@ -112,8 +112,8 @@ package flixel.system.render.blitting
 		 * This method is an imitation of <code>BitmapData#draw()</code>.
 		 * 
 		 * @param	Camera				The camera that is being rendered to the screen at the moment.
-		 * @param	SourceTexture		TODO: encapsulate it under FlxTexture.
-		 * @param	Source				TODO: encapsulate it under FlxTexture.
+		 * @param	SourceTexture		A GPU texture representing the graphic to be rendered.
+		 * @param	Source				A bitmapData representing the graphic to be rendered.
 		 * @param	SourceRect			A rectangle that defines the area of the source image to use as input.
 		 * @param	TransMatrix			A Matrix object used to scale, rotate, or translate the coordinates of the input. It's <code>null</code> by default, meaning no transformation will be applied.
 		 * @param	ColorTrans			A ColorTransform object used to adjust the color values of the input during rendering. It's <code>null</code> by default, meaning no transformation will be applied.
@@ -121,7 +121,7 @@ package flixel.system.render.blitting
 		 * @param	ClipRect			A Rectangle object that defines the area of the source object to draw. If <code>null</code> is provided (default), no clipping occurs and the entire source object is drawn.
 		 * @param	Smoothing			A Boolean value that determines whether a the source object is smoothed when scaled or rotated, due to a scaling or rotation in the Matrix parameter.
 		 */
-		public function draw(Camera:FlxCamera, SourceTexture:GTexture, Source:IBitmapDrawable, SourceRect:Rectangle, TransMatrix:Matrix = null, ColorTrans:ColorTransform = null, BlendMode:String = null, ClipRect:Rectangle = null, Smoothing:Boolean = false):void
+		public function draw(Camera:FlxCamera, SourceTexture:FlxTexture, Source:IBitmapDrawable, SourceRect:Rectangle, TransMatrix:Matrix = null, ColorTrans:ColorTransform = null, BlendMode:String = null, ClipRect:Rectangle = null, Smoothing:Boolean = false):void
 		{
 			Camera.buffer.draw(Source, TransMatrix, ColorTrans, BlendMode, ClipRect, Smoothing);
 		}

--- a/src/flixel/system/render/blitting/FlxBlittingRender.as
+++ b/src/flixel/system/render/blitting/FlxBlittingRender.as
@@ -85,47 +85,45 @@ package flixel.system.render.blitting
 		}
 		
 		/**
-		 * Provides a fast routine to perform pixel copying between the source and the screen with no stretching,
-		 * rotation, or color effects. This method copies a rectangular area of a source image to a
-		 * rectangular area of the same size at the destination point of the informed destination.
-		 * 
-		 * This method is an imitation of <code>BitmapData#copyPixels()</code>.
+		 * Draw the source object into the screen with no stretching, rotation, or color effects. 
+		 * This method renders a rectangular area of a source image to a rectangular area of the same size
+		 * at the destination point of the informed destination.
 		 * 
 		 * @param	Camera				The camera that is being rendered to the screen at the moment.
-		 * @param	sourceTexture		TODO: encapsulate it under FlxTexture.
-		 * @param	sourceBitmapData	TODO: encapsulate it under FlxTexture.
-		 * @param	sourceRect			A rectangle that defines the area of the source image to use as input.
-		 * @param	destPoint			The destination point that represents the upper-left corner of the rectangular area where the new pixels are placed.
-		 * @param	alphaBitmapData		A secondary, alpha BitmapData object source.
-		 * @param	alphaPoint			The point in the alpha BitmapData object source that corresponds to the upper-left corner of the sourceRect parameter.
-		 * @param	mergeAlpha			To use the alpha channel, set the value to true. To copy pixels with no alpha channel, set the value to <code>false</code>
+		 * @param	SourceTexture		TODO: encapsulate it under FlxTexture.
+		 * @param	SourceBitmapData	TODO: encapsulate it under FlxTexture.
+		 * @param	SourceRect			A rectangle that defines the area of the source image to use as input.
+		 * @param	DestPoint			The destination point that represents the upper-left corner of the rectangular area where the new pixels are placed.
+		 * @param	AlphaBitmapData		A secondary, alpha BitmapData object source.
+		 * @param	AlphaPoint			The point in the alpha BitmapData object source that corresponds to the upper-left corner of the SourceRect parameter.
+		 * @param	MergeAlpha			To use the alpha channel, set the value to true. To copy pixels with no alpha channel, set the value to <code>false</code>
 		 */
-		public function copyPixels(Camera:FlxCamera, sourceTexture:GTexture,sourceBitmapData:BitmapData, sourceRect:Rectangle, destPoint:Point, alphaBitmapData:BitmapData = null, alphaPoint:Point = null, mergeAlpha:Boolean = false):void
+		public function copyPixels(Camera:FlxCamera, SourceTexture:GTexture, SourceBitmapData:BitmapData, SourceRect:Rectangle, DestPoint:Point, AlphaBitmapData:BitmapData = null, AlphaPoint:Point = null, MergeAlpha:Boolean = false):void
 		{
-			Camera.buffer.copyPixels(sourceBitmapData, sourceRect, destPoint, alphaBitmapData, alphaPoint, mergeAlpha);
+			Camera.buffer.copyPixels(SourceBitmapData, SourceRect, DestPoint, AlphaBitmapData, AlphaPoint, MergeAlpha);
 		}
 		
 		/**
-		 * Draws the source display object onto the screen using transformations. You can specify matrix, colorTransform, 
-		 * blendMode, and a destination clipRect parameter to control how the rendering performs.
+		 * Draws the source display object into the screen using transformations. You can specify matrix, colorTransform, 
+		 * blendMode, and a destination ClipRect parameter to control how the rendering performs.
 		 * Optionally, you can specify whether the bitmap should be smoothed when scaled (this works only if the source object
 		 * is a BitmapData object).
 		 * 
 		 * This method is an imitation of <code>BitmapData#draw()</code>.
 		 * 
 		 * @param	Camera				The camera that is being rendered to the screen at the moment.
-		 * @param	sourceTexture		TODO: encapsulate it under FlxTexture.
-		 * @param	source				TODO: encapsulate it under FlxTexture.
-		 * @param	sourceRect			A rectangle that defines the area of the source image to use as input.
-		 * @param	matrix				A Matrix object used to scale, rotate, or translate the coordinates of the input. It's <code>null</code> by default, meaning no transformation will be applied.
-		 * @param	colorTransform		A ColorTransform object used to adjust the color values of the input during rendering. It's <code>null</code> by default, meaning no transformation will be applied.
-		 * @param	blendMode			A string value, from the <code>flash.display.BlendMode</code> class, specifying the blend mode to be applied during rendering.
-		 * @param	clipRect			A Rectangle object that defines the area of the source object to draw. If <code>null</code> is provided (default), no clipping occurs and the entire source object is drawn.
-		 * @param	smoothing			A Boolean value that determines whether a the source object is smoothed when scaled or rotated, due to a scaling or rotation in the matrix parameter.
+		 * @param	SourceTexture		TODO: encapsulate it under FlxTexture.
+		 * @param	Source				TODO: encapsulate it under FlxTexture.
+		 * @param	SourceRect			A rectangle that defines the area of the source image to use as input.
+		 * @param	TransMatrix			A Matrix object used to scale, rotate, or translate the coordinates of the input. It's <code>null</code> by default, meaning no transformation will be applied.
+		 * @param	ColorTrans			A ColorTransform object used to adjust the color values of the input during rendering. It's <code>null</code> by default, meaning no transformation will be applied.
+		 * @param	BlendMode			A string value, from the <code>flash.display.BlendMode</code> class, specifying the blend mode to be applied during rendering.
+		 * @param	ClipRect			A Rectangle object that defines the area of the source object to draw. If <code>null</code> is provided (default), no clipping occurs and the entire source object is drawn.
+		 * @param	Smoothing			A Boolean value that determines whether a the source object is smoothed when scaled or rotated, due to a scaling or rotation in the Matrix parameter.
 		 */
-		public function draw(Camera:FlxCamera, sourceTexture:GTexture, source:IBitmapDrawable, sourceRect:Rectangle, matrix:Matrix = null, colorTransform:ColorTransform = null, blendMode:String = null, clipRect:Rectangle = null, smoothing:Boolean = false):void
+		public function draw(Camera:FlxCamera, SourceTexture:GTexture, Source:IBitmapDrawable, SourceRect:Rectangle, TransMatrix:Matrix = null, ColorTrans:ColorTransform = null, BlendMode:String = null, ClipRect:Rectangle = null, Smoothing:Boolean = false):void
 		{
-			Camera.buffer.draw(source, matrix, colorTransform, blendMode, clipRect, smoothing);
+			Camera.buffer.draw(Source, TransMatrix, ColorTrans, BlendMode, ClipRect, Smoothing);
 		}
 		
 		/**
@@ -136,9 +134,9 @@ package flixel.system.render.blitting
 		 * @param	Camera				The camera that is being rendered to the screen at the moment.
 		 * @param	source				The display object or BitmapData object to draw to the BitmapData object.
 		 */
-		public function drawDebug(Camera:FlxCamera, source:IBitmapDrawable):void
+		public function drawDebug(Camera:FlxCamera, Source:IBitmapDrawable):void
 		{
-			Camera.buffer.draw(source);
+			Camera.buffer.draw(Source);
 		}
 	}
 }

--- a/src/flixel/system/render/blitting/FlxBlittingRender.as
+++ b/src/flixel/system/render/blitting/FlxBlittingRender.as
@@ -24,16 +24,6 @@ package flixel.system.render.blitting
 		
 		public function draw(State:FlxState):void
 		{
-			lockCameras();
-			State.draw();
-			unlockCameras();
-		}
-		
-		/**
-		 * Called by the game object to lock all the camera buffers and clear them for the next draw pass.
-		 */
-		private function lockCameras():void
-		{
 			var cam:FlxCamera;
 			var cams:Array = FlxG.cameras;
 			var i:uint = 0;
@@ -43,30 +33,17 @@ package flixel.system.render.blitting
 				cam = cams[i++] as FlxCamera;
 				if((cam == null) || !cam.exists || !cam.visible)
 					continue;
-				//if(FlxG.useBufferLocking)
-					//cam.buffer.lock(); TODO: fix it
+				
+				if(FlxG.useBufferLocking)
+					cam.buffer.lock();
+				
 				cam.fill(cam.bgColor);
 				cam.screen.dirty = true;
-			}
-		}
-		
-		/**
-		 * Called by the game object to draw the special FX and unlock all the camera buffers.
-		 */
-		private function unlockCameras():void
-		{
-			var cam:FlxCamera;
-			var cams:Array = FlxG.cameras;
-			var i:uint = 0;
-			var l:uint = cams.length;
-			while(i < l)
-			{
-				cam = cams[i++] as FlxCamera;
-				if((cam == null) || !cam.exists || !cam.visible)
-					continue;
+				State.draw(cam);
 				cam.drawFX();
-				//if(FlxG.useBufferLocking)
-					//cam.buffer.unlock(); TODO: fix it
+				
+				if(FlxG.useBufferLocking)
+					cam.buffer.unlock();
 			}
 		}
 		

--- a/src/flixel/system/render/blitting/FlxBlittingRender.as
+++ b/src/flixel/system/render/blitting/FlxBlittingRender.as
@@ -1,5 +1,6 @@
 package flixel.system.render.blitting 
 {
+	import com.genome2d.textures.GTexture;
 	import flash.display.BitmapData;
 	import flash.display.IBitmapDrawable;
 	import flash.events.Event;
@@ -80,7 +81,7 @@ package flixel.system.render.blitting
 		 * @param	alphaPoint
 		 * @param	mergeAlpha
 		 */
-		public function copyPixelsToBuffer(Camera:FlxCamera, sourceBitmapData:BitmapData, sourceRect:Rectangle, destPoint:Point, alphaBitmapData:BitmapData=null, alphaPoint:Point=null, mergeAlpha:Boolean=false):void
+		public function copyPixelsToBuffer(Camera:FlxCamera, sourceTexture:GTexture,sourceBitmapData:BitmapData, sourceRect:Rectangle, destPoint:Point, alphaBitmapData:BitmapData = null, alphaPoint:Point = null, mergeAlpha:Boolean = false):void
 		{
 			Camera.buffer.copyPixels(sourceBitmapData, sourceRect, destPoint, alphaBitmapData, alphaPoint, mergeAlpha);
 		}
@@ -96,7 +97,7 @@ package flixel.system.render.blitting
 		 * @param	clipRect
 		 * @param	smoothing
 		 */
-		public function drawToBuffer(Camera:FlxCamera, source:IBitmapDrawable, matrix:Matrix=null, colorTransform:ColorTransform=null, blendMode:String=null, clipRect:Rectangle=null, smoothing:Boolean=false):void
+		public function drawToBuffer(Camera:FlxCamera, sourceTexture:GTexture, source:IBitmapDrawable, sourceRect:Rectangle, matrix:Matrix = null, colorTransform:ColorTransform = null, blendMode:String = null, clipRect:Rectangle = null, smoothing:Boolean = false):void
 		{
 			Camera.buffer.draw(source, matrix, colorTransform, blendMode, clipRect, smoothing);
 		}

--- a/src/flixel/system/render/blitting/FlxBlittingRender.as
+++ b/src/flixel/system/render/blitting/FlxBlittingRender.as
@@ -1,6 +1,12 @@
 package flixel.system.render.blitting 
 {
+	import flash.display.BitmapData;
+	import flash.display.IBitmapDrawable;
 	import flash.events.Event;
+	import flash.geom.ColorTransform;
+	import flash.geom.Matrix;
+	import flash.geom.Point;
+	import flash.geom.Rectangle;
 	import flixel.*;
 	import flixel.system.render.FlxRender;
 	
@@ -36,8 +42,8 @@ package flixel.system.render.blitting
 				cam = cams[i++] as FlxCamera;
 				if((cam == null) || !cam.exists || !cam.visible)
 					continue;
-				if(FlxG.useBufferLocking)
-					cam.buffer.lock();
+				//if(FlxG.useBufferLocking)
+					//cam.buffer.lock(); TODO: fix it
 				cam.fill(cam.bgColor);
 				cam.screen.dirty = true;
 			}
@@ -58,9 +64,41 @@ package flixel.system.render.blitting
 				if((cam == null) || !cam.exists || !cam.visible)
 					continue;
 				cam.drawFX();
-				if(FlxG.useBufferLocking)
-					cam.buffer.unlock();
+				//if(FlxG.useBufferLocking)
+					//cam.buffer.unlock(); TODO: fix it
 			}
+		}
+		
+		/**
+		 * TODO: Render: add docs.
+		 * 
+		 * @param	Camera
+		 * @param	sourceBitmapData
+		 * @param	sourceRect
+		 * @param	destPoint
+		 * @param	alphaBitmapData
+		 * @param	alphaPoint
+		 * @param	mergeAlpha
+		 */
+		public function copyPixelsToBuffer(Camera:FlxCamera, sourceBitmapData:BitmapData, sourceRect:Rectangle, destPoint:Point, alphaBitmapData:BitmapData=null, alphaPoint:Point=null, mergeAlpha:Boolean=false):void
+		{
+			Camera.buffer.copyPixels(sourceBitmapData, sourceRect, destPoint, alphaBitmapData, alphaPoint, mergeAlpha);
+		}
+		
+		/**
+		 * TODO: Render: add docs.
+		 * 
+		 * @param	Camera
+		 * @param	source
+		 * @param	matrix
+		 * @param	colorTransform
+		 * @param	blendMode
+		 * @param	clipRect
+		 * @param	smoothing
+		 */
+		public function drawToBuffer(Camera:FlxCamera, source:IBitmapDrawable, matrix:Matrix=null, colorTransform:ColorTransform=null, blendMode:String=null, clipRect:Rectangle=null, smoothing:Boolean=false):void
+		{
+			Camera.buffer.draw(source, matrix, colorTransform, blendMode, clipRect, smoothing);
 		}
 	}
 }

--- a/src/flixel/system/render/blitting/FlxBlittingRender.as
+++ b/src/flixel/system/render/blitting/FlxBlittingRender.as
@@ -1,5 +1,6 @@
 package flixel.system.render.blitting 
 {
+	import flash.events.Event;
 	import flixel.FlxGame;
 	import flixel.system.render.FlxRender;
 	
@@ -7,15 +8,11 @@ package flixel.system.render.blitting
 	 * TODO: add docs
 	 * @author Dovyski
 	 */
-	public class FlxBlittingRender extends FlxRender
+	public class FlxBlittingRender implements FlxRender
 	{
-		
-		public function FlxBlittingRender(Game:FlxGame, StartGameCallback:Function) 
+		public function init(Game:FlxGame, UpdateCallback:Function):void 
 		{
-			super(Game, StartGameCallback);
-			
-			// Nothing to init here, just tell Flixel the render is ready to roll!
-			StartGameCallback();
+			Game.stage.addEventListener(Event.ENTER_FRAME, UpdateCallback);
 		}
 	}
 }

--- a/src/flixel/system/render/blitting/FlxBlittingRender.as
+++ b/src/flixel/system/render/blitting/FlxBlittingRender.as
@@ -52,7 +52,14 @@ package flixel.system.render.blitting
 			return true;
 		}
 		
-		public function draw(State:FlxState):void
+		/**
+		 * Performs a graphic step, rendering all elements into the screen. Flixel will invoke this method after
+		 * it has updated all game entities. This method *should not* be invoked directly since Flixel will do
+		 * it automatically at the right time.
+		 * 
+		 * @param	State	The state whose elements will be rendered into the screen.
+		 */
+		public function step(State:FlxState):void
 		{
 			var cam:FlxCamera;
 			var cams:Array = FlxG.cameras;
@@ -78,35 +85,60 @@ package flixel.system.render.blitting
 		}
 		
 		/**
-		 * TODO: Render: add docs.
+		 * Provides a fast routine to perform pixel copying between the source and the screen with no stretching,
+		 * rotation, or color effects. This method copies a rectangular area of a source image to a
+		 * rectangular area of the same size at the destination point of the informed destination.
 		 * 
-		 * @param	Camera
-		 * @param	sourceBitmapData
-		 * @param	sourceRect
-		 * @param	destPoint
-		 * @param	alphaBitmapData
-		 * @param	alphaPoint
-		 * @param	mergeAlpha
+		 * This method is an imitation of <code>BitmapData#copyPixels()</code>.
+		 * 
+		 * @param	Camera				The camera that is being rendered to the screen at the moment.
+		 * @param	sourceTexture		TODO: encapsulate it under FlxTexture.
+		 * @param	sourceBitmapData	TODO: encapsulate it under FlxTexture.
+		 * @param	sourceRect			A rectangle that defines the area of the source image to use as input.
+		 * @param	destPoint			The destination point that represents the upper-left corner of the rectangular area where the new pixels are placed.
+		 * @param	alphaBitmapData		A secondary, alpha BitmapData object source.
+		 * @param	alphaPoint			The point in the alpha BitmapData object source that corresponds to the upper-left corner of the sourceRect parameter.
+		 * @param	mergeAlpha			To use the alpha channel, set the value to true. To copy pixels with no alpha channel, set the value to <code>false</code>
 		 */
-		public function copyPixelsToBuffer(Camera:FlxCamera, sourceTexture:GTexture,sourceBitmapData:BitmapData, sourceRect:Rectangle, destPoint:Point, alphaBitmapData:BitmapData = null, alphaPoint:Point = null, mergeAlpha:Boolean = false):void
+		public function copyPixels(Camera:FlxCamera, sourceTexture:GTexture,sourceBitmapData:BitmapData, sourceRect:Rectangle, destPoint:Point, alphaBitmapData:BitmapData = null, alphaPoint:Point = null, mergeAlpha:Boolean = false):void
 		{
 			Camera.buffer.copyPixels(sourceBitmapData, sourceRect, destPoint, alphaBitmapData, alphaPoint, mergeAlpha);
 		}
 		
 		/**
-		 * TODO: Render: add docs.
+		 * Draws the source display object onto the screen using transformations. You can specify matrix, colorTransform, 
+		 * blendMode, and a destination clipRect parameter to control how the rendering performs.
+		 * Optionally, you can specify whether the bitmap should be smoothed when scaled (this works only if the source object
+		 * is a BitmapData object).
 		 * 
-		 * @param	Camera
-		 * @param	source
-		 * @param	matrix
-		 * @param	colorTransform
-		 * @param	blendMode
-		 * @param	clipRect
-		 * @param	smoothing
+		 * This method is an imitation of <code>BitmapData#draw()</code>.
+		 * 
+		 * @param	Camera				The camera that is being rendered to the screen at the moment.
+		 * @param	sourceTexture		TODO: encapsulate it under FlxTexture.
+		 * @param	source				TODO: encapsulate it under FlxTexture.
+		 * @param	sourceRect			A rectangle that defines the area of the source image to use as input.
+		 * @param	matrix				A Matrix object used to scale, rotate, or translate the coordinates of the input. It's <code>null</code> by default, meaning no transformation will be applied.
+		 * @param	colorTransform		A ColorTransform object used to adjust the color values of the input during rendering. It's <code>null</code> by default, meaning no transformation will be applied.
+		 * @param	blendMode			A string value, from the <code>flash.display.BlendMode</code> class, specifying the blend mode to be applied during rendering.
+		 * @param	clipRect			A Rectangle object that defines the area of the source object to draw. If <code>null</code> is provided (default), no clipping occurs and the entire source object is drawn.
+		 * @param	smoothing			A Boolean value that determines whether a the source object is smoothed when scaled or rotated, due to a scaling or rotation in the matrix parameter.
 		 */
-		public function drawToBuffer(Camera:FlxCamera, sourceTexture:GTexture, source:IBitmapDrawable, sourceRect:Rectangle, matrix:Matrix = null, colorTransform:ColorTransform = null, blendMode:String = null, clipRect:Rectangle = null, smoothing:Boolean = false):void
+		public function draw(Camera:FlxCamera, sourceTexture:GTexture, source:IBitmapDrawable, sourceRect:Rectangle, matrix:Matrix = null, colorTransform:ColorTransform = null, blendMode:String = null, clipRect:Rectangle = null, smoothing:Boolean = false):void
 		{
 			Camera.buffer.draw(source, matrix, colorTransform, blendMode, clipRect, smoothing);
+		}
+		
+		/**
+		 * Draws generic graphics to the screen using a blitting debug buffer. Highly changing graphics, such as debug lines, cannot be uploaed to
+		 * the GPU every frame, so the render provides this method that renders a source object to a special buffer using blitting.
+		 * This method should be used when performance is not a concern, e.g. when debug overlays are being rendered.
+		 * 
+		 * @param	Camera				The camera that is being rendered to the screen at the moment.
+		 * @param	source				The display object or BitmapData object to draw to the BitmapData object.
+		 */
+		public function drawDebug(Camera:FlxCamera, source:IBitmapDrawable):void
+		{
+			Camera.buffer.draw(source);
 		}
 	}
 }

--- a/src/flixel/system/render/blitting/FlxBlittingRender.as
+++ b/src/flixel/system/render/blitting/FlxBlittingRender.as
@@ -12,14 +12,44 @@ package flixel.system.render.blitting
 	import flixel.system.render.FlxRender;
 	
 	/**
-	 * TODO: add docs
+	 * A CPU render based on blitting. It uses Bitmaps draw thing into the screen, copying pixels
+	 * from one place to another. It is not based on hardware acceleration, so it tends to be slower as the
+	 * number of sprites to be rendered increases.
+	 * 
 	 * @author Dovyski
 	 */
 	public class FlxBlittingRender implements FlxRender
 	{
+		/**
+		 * Initializes the render.
+		 * 
+		 * @param	Game				A reference to the game object.
+		 * @param	StartGameCallback	A callback function in the form <code>callback(e:FlashEvent=null)</code> that will be invoked by the render whenever it is ready to process the next frame.
+		 */		
 		public function init(Game:FlxGame, UpdateCallback:Function):void 
 		{
 			Game.stage.addEventListener(Event.ENTER_FRAME, UpdateCallback);
+		}
+		
+		/**
+		 * Returns a few information about the render. That info displayed at the bottom of the performance
+		 * overlay when debug information is active.
+		 * 
+		 * @return A string containing information about the render, e.g. "Blitting" or "GPU (Genome2D)".
+		 */
+		public function get info():String
+		{
+			return "CPU Blitting";
+		}
+		
+		/**
+		 * Tells if the render is working with blitting (copying pixels using BitmapData) or not.
+		 * 
+		 * @return <code>true</code> true if blitting is being used to display things into the screen, or <code>false</code> otherwise (using GPU).
+		 */
+		public function isBlitting():Boolean
+		{
+			return true;
 		}
 		
 		public function draw(State:FlxState):void

--- a/src/flixel/system/render/blitting/FlxBlittingRender.as
+++ b/src/flixel/system/render/blitting/FlxBlittingRender.as
@@ -1,7 +1,7 @@
 package flixel.system.render.blitting 
 {
 	import flash.events.Event;
-	import flixel.FlxGame;
+	import flixel.*;
 	import flixel.system.render.FlxRender;
 	
 	/**
@@ -13,6 +13,54 @@ package flixel.system.render.blitting
 		public function init(Game:FlxGame, UpdateCallback:Function):void 
 		{
 			Game.stage.addEventListener(Event.ENTER_FRAME, UpdateCallback);
+		}
+		
+		public function draw(State:FlxState):void
+		{
+			lockCameras();
+			State.draw();
+			unlockCameras();
+		}
+		
+		/**
+		 * Called by the game object to lock all the camera buffers and clear them for the next draw pass.
+		 */
+		private function lockCameras():void
+		{
+			var cam:FlxCamera;
+			var cams:Array = FlxG.cameras;
+			var i:uint = 0;
+			var l:uint = cams.length;
+			while(i < l)
+			{
+				cam = cams[i++] as FlxCamera;
+				if((cam == null) || !cam.exists || !cam.visible)
+					continue;
+				if(FlxG.useBufferLocking)
+					cam.buffer.lock();
+				cam.fill(cam.bgColor);
+				cam.screen.dirty = true;
+			}
+		}
+		
+		/**
+		 * Called by the game object to draw the special FX and unlock all the camera buffers.
+		 */
+		private function unlockCameras():void
+		{
+			var cam:FlxCamera;
+			var cams:Array = FlxG.cameras;
+			var i:uint = 0;
+			var l:uint = cams.length;
+			while(i < l)
+			{
+				cam = cams[i++] as FlxCamera;
+				if((cam == null) || !cam.exists || !cam.visible)
+					continue;
+				cam.drawFX();
+				if(FlxG.useBufferLocking)
+					cam.buffer.unlock();
+			}
 		}
 	}
 }

--- a/src/flixel/system/render/genome2d/FlxGenome2DRender.as
+++ b/src/flixel/system/render/genome2d/FlxGenome2DRender.as
@@ -244,31 +244,37 @@ package flixel.system.render.genome2d
 		
 		/**
 		 * Draws the source display object into the screen using transformations. You can specify matrix, colorTransform, 
-		 * blendMode, and a destination clipRect parameter to control how the rendering performs.
+		 * blendMode, and a destination ClipRect parameter to control how the rendering performs.
 		 * Optionally, you can specify whether the bitmap should be smoothed when scaled (this works only if the source object
 		 * is a BitmapData object).
 		 * 
 		 * This method is an imitation of <code>BitmapData#draw()</code>.
 		 * 
 		 * @param	Camera				The camera that is being rendered to the screen at the moment.
-		 * @param	sourceTexture		TODO: encapsulate it under FlxTexture.
-		 * @param	source				TODO: encapsulate it under FlxTexture.
-		 * @param	sourceRect			A rectangle that defines the area of the source image to use as input.
-		 * @param	matrix				A Matrix object used to scale, rotate, or translate the coordinates of the input. It's <code>null</code> by default, meaning no transformation will be applied.
-		 * @param	colorTransform		A ColorTransform object used to adjust the color values of the input during rendering. It's <code>null</code> by default, meaning no transformation will be applied.
-		 * @param	blendMode			A string value, from the <code>flash.display.BlendMode</code> class, specifying the blend mode to be applied during rendering.
-		 * @param	clipRect			A Rectangle object that defines the area of the source object to draw. If <code>null</code> is provided (default), no clipping occurs and the entire source object is drawn.
-		 * @param	smoothing			A Boolean value that determines whether a the source object is smoothed when scaled or rotated, due to a scaling or rotation in the matrix parameter.
+		 * @param	SourceTexture		TODO: encapsulate it under FlxTexture.
+		 * @param	Source				TODO: encapsulate it under FlxTexture.
+		 * @param	SourceRect			A rectangle that defines the area of the source image to use as input.
+		 * @param	TransMatrix			A Matrix object used to scale, rotate, or translate the coordinates of the input. It's <code>null</code> by default, meaning no transformation will be applied.
+		 * @param	ColorTrans			A ColorTransform object used to adjust the color values of the input during rendering. It's <code>null</code> by default, meaning no transformation will be applied.
+		 * @param	BlendMode			A string value, from the <code>flash.display.BlendMode</code> class, specifying the blend mode to be applied during rendering.
+		 * @param	ClipRect			A Rectangle object that defines the area of the source object to draw. If <code>null</code> is provided (default), no clipping occurs and the entire source object is drawn.
+		 * @param	Smoothing			A Boolean value that determines whether a the source object is smoothed when scaled or rotated, due to a scaling or rotation in the Matrix parameter.
 		 */
-		public function draw(Camera:FlxCamera, sourceTexture:GTexture, source:IBitmapDrawable, sourceRect:Rectangle, matrix:Matrix = null, colorTransform:ColorTransform = null, blendMode:String = null, clipRect:Rectangle = null, smoothing:Boolean = false):void
+		public function draw(Camera:FlxCamera, SourceTexture:GTexture, Source:IBitmapDrawable, SourceRect:Rectangle, TransMatrix:Matrix = null, ColorTrans:ColorTransform = null, BlendMode:String = null, ClipRect:Rectangle = null, Smoothing:Boolean = false):void
 		{
-			var context:IContext;
-			
-			context = _genome.getContext();
+			var context:IContext = _genome.getContext();
 
-			context.setBackgroundColor(Camera.bgColor);
-			context.setMaskRect(new Rectangle(Camera.x * Camera.zoom, Camera.y * Camera.zoom, Camera.width * Camera.zoom, Camera.height * Camera.zoom));
-			context.drawMatrixSource(sourceTexture, sourceRect.x, sourceRect.y, sourceRect.width, sourceRect.height, matrix.a * Camera.zoom, matrix.b * Camera.zoom, matrix.c * Camera.zoom, matrix.d * Camera.zoom, (matrix.tx + Camera.fxShakeOffset.x) * Camera.zoom, (matrix.ty + Camera.fxShakeOffset.y) * Camera.zoom);
+			context.drawMatrixSource(SourceTexture,
+									 SourceRect.x,
+									 SourceRect.y,
+									 SourceRect.width,
+									 SourceRect.height,
+									 TransMatrix.a * Camera.zoom,
+									 TransMatrix.b * Camera.zoom,
+									 TransMatrix.c * Camera.zoom,
+									 TransMatrix.d * Camera.zoom,
+									 (TransMatrix.tx + Camera.fxShakeOffset.x) * Camera.zoom,
+									 (TransMatrix.ty + Camera.fxShakeOffset.y) * Camera.zoom);
 		}
 		
 		/**

--- a/src/flixel/system/render/genome2d/FlxGenome2DRender.as
+++ b/src/flixel/system/render/genome2d/FlxGenome2DRender.as
@@ -75,6 +75,8 @@ package flixel.system.render.genome2d
 		public function copyPixelsToBuffer(Camera:FlxCamera, sourceTexture:GTexture, sourceBitmapData:BitmapData, sourceRect:Rectangle, destPoint:Point, alphaBitmapData:BitmapData = null, alphaPoint:Point = null, mergeAlpha:Boolean = false):void
 		{
 			var context:IContext = genome.getContext();
+			
+			context.setBackgroundColor(Camera.bgColor);
 			context.drawSource(sourceTexture, sourceRect.x, sourceRect.y, sourceRect.width, sourceRect.height, (destPoint.x + sourceRect.width/2) * Camera.zoom, (destPoint.y + sourceRect.height/2) * Camera.zoom, Camera.zoom, Camera.zoom);
 		}
 		
@@ -94,6 +96,8 @@ package flixel.system.render.genome2d
 		public function drawToBuffer(Camera:FlxCamera, sourceTexture:GTexture, source:IBitmapDrawable, sourceRect:Rectangle, matrix:Matrix = null, colorTransform:ColorTransform = null, blendMode:String = null, clipRect:Rectangle = null, smoothing:Boolean = false):void
 		{
 			var context:IContext = genome.getContext();
+
+			context.setBackgroundColor(Camera.bgColor);
 			// TODO: fix matrix rotation using wrong pivot.
 			context.drawMatrixSource(sourceTexture, sourceRect.x, sourceRect.y, sourceRect.width, sourceRect.height, matrix.a * Camera.zoom, matrix.b * Camera.zoom, matrix.c * Camera.zoom, matrix.d * Camera.zoom, matrix.tx * Camera.zoom, matrix.ty * Camera.zoom);
 		}

--- a/src/flixel/system/render/genome2d/FlxGenome2DRender.as
+++ b/src/flixel/system/render/genome2d/FlxGenome2DRender.as
@@ -26,9 +26,6 @@ package flixel.system.render.genome2d
 	 */
 	public class FlxGenome2DRender implements FlxRender
 	{
-		[Embed(source="../../../../../../../FlixelSandbox/assets/bunny.png")] private var TexturePNG:Class;
-		
-		private var texture:GTexture;
 		private var genome:Genome2D;
 		private var updateCallback:Function;
 		
@@ -75,14 +72,10 @@ package flixel.system.render.genome2d
 		 * @param	alphaPoint
 		 * @param	mergeAlpha
 		 */
-		public function copyPixelsToBuffer(Camera:FlxCamera, sourceBitmapData:BitmapData, sourceRect:Rectangle, destPoint:Point, alphaBitmapData:BitmapData = null, alphaPoint:Point = null, mergeAlpha:Boolean = false):void
+		public function copyPixelsToBuffer(Camera:FlxCamera, sourceTexture:GTexture, sourceBitmapData:BitmapData, sourceRect:Rectangle, destPoint:Point, alphaBitmapData:BitmapData = null, alphaPoint:Point = null, mergeAlpha:Boolean = false):void
 		{
 			var context:IContext = genome.getContext();
-			
-			if(texture == null) {
-				texture = GTextureFactory.createFromBitmapData("texture2", sourceBitmapData);
-			}
-			context.draw(texture, destPoint.x * Camera.zoom, destPoint.y * Camera.zoom, Camera.zoom, Camera.zoom);
+			context.drawSource(sourceTexture, sourceRect.x, sourceRect.y, sourceRect.width, sourceRect.height, destPoint.x * Camera.zoom, destPoint.y * Camera.zoom, Camera.zoom, Camera.zoom);
 		}
 		
 		/**
@@ -91,21 +84,18 @@ package flixel.system.render.genome2d
 		 * 
 		 * @param	Camera
 		 * @param	source
+		 * @param	sourceRect
 		 * @param	matrix
 		 * @param	colorTransform
 		 * @param	blendMode
 		 * @param	clipRect
 		 * @param	smoothing
 		 */
-		public function drawToBuffer(Camera:FlxCamera, source:IBitmapDrawable, matrix:Matrix = null, colorTransform:ColorTransform = null, blendMode:String = null, clipRect:Rectangle = null, smoothing:Boolean = false):void
+		public function drawToBuffer(Camera:FlxCamera, sourceTexture:GTexture, source:IBitmapDrawable, sourceRect:Rectangle, matrix:Matrix = null, colorTransform:ColorTransform = null, blendMode:String = null, clipRect:Rectangle = null, smoothing:Boolean = false):void
 		{
 			var context:IContext = genome.getContext();
-			
-			if(texture == null) {
-				texture = GTextureFactory.createFromBitmapData("texture2", source as BitmapData);
-			}
-
-			context.drawMatrix(texture, matrix.a * Camera.zoom, matrix.b * Camera.zoom, matrix.c * Camera.zoom, matrix.d * Camera.zoom, matrix.tx * Camera.zoom, matrix.ty * Camera.zoom);
+			// TODO: fix matrix rotation using wrong pivot.
+			context.drawMatrixSource(sourceTexture, sourceRect.x, sourceRect.y, sourceRect.width, sourceRect.height, matrix.a * Camera.zoom, matrix.b * Camera.zoom, matrix.c * Camera.zoom, matrix.d * Camera.zoom, matrix.tx * Camera.zoom, matrix.ty * Camera.zoom);
 		}
 	}
 }

--- a/src/flixel/system/render/genome2d/FlxGenome2DRender.as
+++ b/src/flixel/system/render/genome2d/FlxGenome2DRender.as
@@ -88,6 +88,7 @@ package flixel.system.render.genome2d
 			// Initialize Genome2D
 			_genome = Genome2D.getInstance();
 			_genome.onInitialized.addOnce(genomeInitializedHandler);
+			_genome.onFailed.addOnce(genomeFailedHandler);
 			_genome.init(_config);
 			
 			_updateCallback = UpdateCallback;
@@ -101,7 +102,6 @@ package flixel.system.render.genome2d
 			Game.parent.addChild(_debugBufferContainer);
 			_debugBufferContainer.visible = false;
 			
-			// TODO: improve this!
 			_matrix = new Matrix();
 			_rect = new Rectangle();
 		}
@@ -125,6 +125,11 @@ package flixel.system.render.genome2d
 		public function isBlitting():Boolean
 		{
 			return false;
+		}
+		
+		private function genomeFailedHandler(ErrorMessage:String):void
+		{
+			FlxG.log("FlxGenome2DRender#init() - " + ErrorMessage);
 		}
 		
 		private function genomeInitializedHandler():void

--- a/src/flixel/system/render/genome2d/FlxGenome2DRender.as
+++ b/src/flixel/system/render/genome2d/FlxGenome2DRender.as
@@ -78,7 +78,7 @@ package flixel.system.render.genome2d
 					continue;
 					
 				context.setMaskRect(new Rectangle(camera.x * camera.zoom, camera.y * camera.zoom, camera.width * camera.zoom, camera.height * camera.zoom)); // TODO: Render: improve rectangle allocation
-				context.draw(camera.texture, (camera.x + camera.width / 2) * camera.zoom, (camera.y + camera.height / 2) * camera.zoom, camera.zoom, camera.zoom, 0, camera.colorTransform.redMultiplier, camera.colorTransform.greenMultiplier, camera.colorTransform.blueMultiplier);
+				context.draw(camera.texture, (camera.fxShakeOffset.x + camera.x + camera.width / 2) * camera.zoom, (camera.fxShakeOffset.y + camera.y + camera.height / 2) * camera.zoom, camera.zoom, camera.zoom, 0, camera.colorTransform.redMultiplier, camera.colorTransform.greenMultiplier, camera.colorTransform.blueMultiplier);
 				
 				var j:uint = 0;
 				while (j < State.members.length)
@@ -122,7 +122,7 @@ package flixel.system.render.genome2d
 			
 			context.setBackgroundColor(Camera.bgColor);
 			context.setMaskRect(new Rectangle(Camera.x * Camera.zoom, Camera.y * Camera.zoom, Camera.width * Camera.zoom, Camera.height * Camera.zoom)); // TODO: improve rectangle allocation
-			context.drawSource(sourceTexture, sourceRect.x, sourceRect.y, sourceRect.width, sourceRect.height, (Camera.x + destPoint.x + sourceRect.width/2) * Camera.zoom, (Camera.y + destPoint.y + sourceRect.height/2) * Camera.zoom, Camera.zoom, Camera.zoom);
+			context.drawSource(sourceTexture, sourceRect.x, sourceRect.y, sourceRect.width, sourceRect.height, (Camera.fxShakeOffset.x + Camera.x + destPoint.x + sourceRect.width/2) * Camera.zoom, (Camera.fxShakeOffset.y + Camera.y + destPoint.y + sourceRect.height/2) * Camera.zoom, Camera.zoom, Camera.zoom);
 		}
 		
 		/**
@@ -144,7 +144,7 @@ package flixel.system.render.genome2d
 
 			context.setBackgroundColor(Camera.bgColor);
 			context.setMaskRect(new Rectangle(Camera.x * Camera.zoom, Camera.y * Camera.zoom, Camera.width * Camera.zoom, Camera.height * Camera.zoom));
-			context.drawMatrixSource(sourceTexture, sourceRect.x, sourceRect.y, sourceRect.width, sourceRect.height, matrix.a * Camera.zoom, matrix.b * Camera.zoom, matrix.c * Camera.zoom, matrix.d * Camera.zoom, matrix.tx * Camera.zoom, matrix.ty * Camera.zoom);
+			context.drawMatrixSource(sourceTexture, sourceRect.x, sourceRect.y, sourceRect.width, sourceRect.height, matrix.a * Camera.zoom, matrix.b * Camera.zoom, matrix.c * Camera.zoom, matrix.d * Camera.zoom, (matrix.tx + Camera.fxShakeOffset.x) * Camera.zoom, (matrix.ty + Camera.fxShakeOffset.y)* Camera.zoom);
 		}
 	}
 }

--- a/src/flixel/system/render/genome2d/FlxGenome2DRender.as
+++ b/src/flixel/system/render/genome2d/FlxGenome2DRender.as
@@ -178,6 +178,7 @@ package flixel.system.render.genome2d
 				renderPosY = (camera.fxShakeOffset.y + camera.y + camera.height / 2) * camera.zoom;
 				
 				// Render the camera background. It's the equivalent of calling camera.fill() in the blitting render.
+				context.setBackgroundColor(camera.bgColor);
 				context.draw(camera.bgTexture.gpuData, renderPosX, renderPosY, camera.zoom, camera.zoom, 0, camera.colorTransform.redMultiplier, camera.colorTransform.greenMultiplier, camera.colorTransform.blueMultiplier);
 				
 				// Iterate over every entry in the state, rendering it.
@@ -218,21 +219,27 @@ package flixel.system.render.genome2d
 		 * at the destination point of the informed destination.
 		 * 
 		 * @param	Camera				The camera that is being rendered to the screen at the moment.
-		 * @param	sourceTexture		TODO: encapsulate it under FlxTexture.
-		 * @param	sourceBitmapData	TODO: encapsulate it under FlxTexture.
-		 * @param	sourceRect			A rectangle that defines the area of the source image to use as input.
-		 * @param	destPoint			The destination point that represents the upper-left corner of the rectangular area where the new pixels are placed.
-		 * @param	alphaBitmapData		A secondary, alpha BitmapData object source.
-		 * @param	alphaPoint			The point in the alpha BitmapData object source that corresponds to the upper-left corner of the sourceRect parameter.
-		 * @param	mergeAlpha			To use the alpha channel, set the value to true. To copy pixels with no alpha channel, set the value to <code>false</code>
+		 * @param	SourceTexture		TODO: encapsulate it under FlxTexture.
+		 * @param	SourceBitmapData	TODO: encapsulate it under FlxTexture.
+		 * @param	SourceRect			A rectangle that defines the area of the source image to use as input.
+		 * @param	DestPoint			The destination point that represents the upper-left corner of the rectangular area where the new pixels are placed.
+		 * @param	AlphaBitmapData		A secondary, alpha BitmapData object source.
+		 * @param	AlphaPoint			The point in the alpha BitmapData object source that corresponds to the upper-left corner of the SourceRect parameter.
+		 * @param	MergeAlpha			To use the alpha channel, set the value to true. To copy pixels with no alpha channel, set the value to <code>false</code>
 		 */
-		public function copyPixels(Camera:FlxCamera, sourceTexture:GTexture, sourceBitmapData:BitmapData, sourceRect:Rectangle, destPoint:Point, alphaBitmapData:BitmapData = null, alphaPoint:Point = null, mergeAlpha:Boolean = false):void
+		public function copyPixels(Camera:FlxCamera, SourceTexture:GTexture, SourceBitmapData:BitmapData, SourceRect:Rectangle, DestPoint:Point, AlphaBitmapData:BitmapData = null, AlphaPoint:Point = null, MergeAlpha:Boolean = false):void
 		{
 			var context:IContext = _genome.getContext();
 			
-			context.setBackgroundColor(Camera.bgColor);
-			context.setMaskRect(new Rectangle(Camera.x * Camera.zoom, Camera.y * Camera.zoom, Camera.width * Camera.zoom, Camera.height * Camera.zoom)); // TODO: improve rectangle allocation
-			context.drawSource(sourceTexture, sourceRect.x, sourceRect.y, sourceRect.width, sourceRect.height, (Camera.fxShakeOffset.x + Camera.x + destPoint.x + sourceRect.width / 2) * Camera.zoom, (Camera.fxShakeOffset.y + Camera.y + destPoint.y + sourceRect.height / 2) * Camera.zoom, Camera.zoom, Camera.zoom);
+			context.drawSource(	SourceTexture,
+								SourceRect.x,
+								SourceRect.y,
+								SourceRect.width,
+								SourceRect.height,
+								(Camera.fxShakeOffset.x + Camera.x + DestPoint.x + SourceRect.width / 2) * Camera.zoom,
+								(Camera.fxShakeOffset.y + Camera.y + DestPoint.y + SourceRect.height / 2) * Camera.zoom,
+								Camera.zoom,
+								Camera.zoom);
 		}
 		
 		/**

--- a/src/flixel/system/render/genome2d/FlxGenome2DRender.as
+++ b/src/flixel/system/render/genome2d/FlxGenome2DRender.as
@@ -75,7 +75,7 @@ package flixel.system.render.genome2d
 		public function copyPixelsToBuffer(Camera:FlxCamera, sourceTexture:GTexture, sourceBitmapData:BitmapData, sourceRect:Rectangle, destPoint:Point, alphaBitmapData:BitmapData = null, alphaPoint:Point = null, mergeAlpha:Boolean = false):void
 		{
 			var context:IContext = genome.getContext();
-			context.drawSource(sourceTexture, sourceRect.x, sourceRect.y, sourceRect.width, sourceRect.height, destPoint.x * Camera.zoom, destPoint.y * Camera.zoom, Camera.zoom, Camera.zoom);
+			context.drawSource(sourceTexture, sourceRect.x, sourceRect.y, sourceRect.width, sourceRect.height, destPoint.x * Camera.zoom + sourceRect.width, destPoint.y * Camera.zoom + sourceRect.height, Camera.zoom, Camera.zoom);
 		}
 		
 		/**

--- a/src/flixel/system/render/genome2d/FlxGenome2DRender.as
+++ b/src/flixel/system/render/genome2d/FlxGenome2DRender.as
@@ -23,9 +23,14 @@ package flixel.system.render.genome2d
 	import flixel.system.render.FlxRender;
 	
 	/**
-	 * TODO: add docs
+	 * A GPU render based on Genome2D (http://genome2d.com). It uses hardware acceleration (GPU) to draw elements into the
+	 * screen, which makes it a lot faster than the blitting render. Since it is lighter on the CPU processing, it should be battery friendly
+	 * and a better fit for mobile development.
 	 * 
-	 * Tutorial from: http://blog.flash-core.com/?p=3132
+	 * This render uses Genome2D low-level API to draw everything. Genome2D's rendering pipeline is significantly different compared to a blitting 
+	 * pipeline, so a few adaptations were made to ensure performance. 
+	 * 
+	 * This render was implemented following this tutorial: http://blog.flash-core.com/?p=3132
 	 * 
 	 * @author Dovyski
 	 */
@@ -39,6 +44,12 @@ package flixel.system.render.genome2d
 		private var debugBufferContainer:Bitmap;
 		private var m:Matrix;
 		
+		/**
+		 * Initializes the render.
+		 * 
+		 * @param	Game				A reference to the game object.
+		 * @param	StartGameCallback	A callback function in the form <code>callback(e:FlashEvent=null)</code> that will be invoked by the render whenever it is ready to process the next frame.
+		 */
 		public function init(Game:FlxGame, UpdateCallback:Function):void
 		{
 			
@@ -62,6 +73,27 @@ package flixel.system.render.genome2d
 			
 			// TODO: improve this!
 			m = new Matrix();
+		}
+		
+		/**
+		 * Returns a few information about the render. That info displayed at the bottom of the performance
+		 * overlay when debug information is active.
+		 * 
+		 * @return A string containing information about the render, e.g. "Blitting" or "GPU (Genome2D)".
+		 */
+		public function get info():String
+		{
+			return "GPU Genome2D " + Genome2D.VERSION;
+		}
+		
+		/**
+		 * Tells if the render is working with blitting (copying pixels using BitmapData) or not.
+		 * 
+		 * @return <code>true</code> true if blitting is being used to display things into the screen, or <code>false</code> otherwise (using GPU).
+		 */
+		public function isBlitting():Boolean
+		{
+			return false;
 		}
 		
 		private function genomeInitializedHandler():void

--- a/src/flixel/system/render/genome2d/FlxGenome2DRender.as
+++ b/src/flixel/system/render/genome2d/FlxGenome2DRender.as
@@ -1,16 +1,20 @@
 package flixel.system.render.genome2d 
 {
+	import com.genome2d.context.GBlendMode;
+	import com.genome2d.context.GContextCamera;
 	import com.genome2d.context.GContextConfig;
 	import com.genome2d.context.IContext;
 	import com.genome2d.Genome2D;
 	import com.genome2d.textures.factories.GTextureFactory;
 	import com.genome2d.textures.GTexture;
 	import flash.display.BitmapData;
+	import flash.display.BlendMode;
 	import flash.display.IBitmapDrawable;
 	import flash.geom.ColorTransform;
 	import flash.geom.Matrix;
 	import flash.geom.Point;
 	import flash.geom.Rectangle;
+	import flixel.FlxBasic;
 	import flixel.FlxCamera;
 	import flixel.FlxG;
 	import flixel.FlxGame;
@@ -54,10 +58,35 @@ package flixel.system.render.genome2d
 		
 		public function draw(State:FlxState):void
 		{
-			//var context:IContext = genome.getContext();
-			//context.draw(texture, 50, 50);
-			//FlxG.log("working?" + FlxG.random.float());
-			State.draw();
+			var context:IContext = genome.getContext();
+			var l:uint = FlxG.cameras.length;
+			var camera:FlxCamera;
+			var basic:FlxBasic;
+			var i:uint = 0;
+			
+			while(i < l)
+			{
+				camera = FlxG.cameras[i++];
+				
+				if(camera == null || !camera.exists || !camera.visible)
+					continue;
+					
+				context.setMaskRect(new Rectangle(camera.x * camera.zoom, camera.y * camera.zoom, camera.width * camera.zoom, camera.height * camera.zoom)); // TODO: Render: improve rectangle allocation
+				context.draw(camera.texture, camera.x + camera.width / 2, camera.y + camera.height / 2, 1, 1, 0, camera.colorTransform.redMultiplier, camera.colorTransform.greenMultiplier, camera.colorTransform.blueMultiplier);
+				
+				var j:uint = 0;
+				while (j < State.members.length)
+				{
+					basic = State.members[j++];
+					
+					if (basic != null && basic.exists && basic.visible)
+					{
+						basic.draw(camera);
+					}
+				}
+				
+				camera.drawFX();
+			}
 		}
 		
 		/**
@@ -77,7 +106,8 @@ package flixel.system.render.genome2d
 			var context:IContext = genome.getContext();
 			
 			context.setBackgroundColor(Camera.bgColor);
-			context.drawSource(sourceTexture, sourceRect.x, sourceRect.y, sourceRect.width, sourceRect.height, (destPoint.x + sourceRect.width/2) * Camera.zoom, (destPoint.y + sourceRect.height/2) * Camera.zoom, Camera.zoom, Camera.zoom);
+			context.setMaskRect(new Rectangle(Camera.x * Camera.zoom, Camera.y * Camera.zoom, Camera.width * Camera.zoom, Camera.height * Camera.zoom)); // TODO: improve rectangle allocation
+			context.drawSource(sourceTexture, sourceRect.x, sourceRect.y, sourceRect.width, sourceRect.height, (Camera.x + destPoint.x + sourceRect.width/2) * Camera.zoom, (Camera.y + destPoint.y + sourceRect.height/2) * Camera.zoom, Camera.zoom, Camera.zoom);
 		}
 		
 		/**
@@ -98,7 +128,7 @@ package flixel.system.render.genome2d
 			var context:IContext = genome.getContext();
 
 			context.setBackgroundColor(Camera.bgColor);
-			// TODO: fix matrix rotation using wrong pivot.
+			context.setMaskRect(new Rectangle(Camera.x * Camera.zoom, Camera.y * Camera.zoom, Camera.width * Camera.zoom, Camera.height * Camera.zoom));
 			context.drawMatrixSource(sourceTexture, sourceRect.x, sourceRect.y, sourceRect.width, sourceRect.height, matrix.a * Camera.zoom, matrix.b * Camera.zoom, matrix.c * Camera.zoom, matrix.d * Camera.zoom, matrix.tx * Camera.zoom, matrix.ty * Camera.zoom);
 		}
 	}

--- a/src/flixel/system/render/genome2d/FlxGenome2DRender.as
+++ b/src/flixel/system/render/genome2d/FlxGenome2DRender.as
@@ -8,6 +8,7 @@ package flixel.system.render.genome2d
 	import flash.geom.Rectangle;
 	import flixel.FlxG;
 	import flixel.FlxGame;
+	import flixel.FlxState;
 	import flixel.system.render.FlxRender;
 	
 	/**
@@ -48,7 +49,7 @@ package flixel.system.render.genome2d
 			genome.onPreRender.add(updateCallback);
 		}
 		
-		private function preRenderHandler():void
+		public function draw(State:FlxState):void
 		{
 			var context:IContext = genome.getContext();
 			context.draw(texture, 50, 50);

--- a/src/flixel/system/render/genome2d/FlxGenome2DRender.as
+++ b/src/flixel/system/render/genome2d/FlxGenome2DRender.as
@@ -17,17 +17,16 @@ package flixel.system.render.genome2d
 	 * 
 	 * @author Dovyski
 	 */
-	public class FlxGenome2DRender extends FlxRender
+	public class FlxGenome2DRender implements FlxRender
 	{
-		[Embed(source="../../../../../../../Testing/src/Ground.png")] private var TexturePNG:Class;
+		[Embed(source="../../../../../../../FlixelSandbox/assets/bunny.png")] private var TexturePNG:Class;
 		
 		private var texture:GTexture;
 		private var genome:Genome2D;
-		private var startGameCallback:Function;
+		private var updateCallback:Function;
 		
-		public function FlxGenome2DRender(Game:FlxGame, StartGameCallback:Function) 
+		public function init(Game:FlxGame, UpdateCallback:Function):void
 		{
-			super(Game, StartGameCallback);
 			
 			var config:GContextConfig = new GContextConfig(Game.stage, new Rectangle(0,0,Game.stage.stageWidth,Game.stage.stageHeight));
 			 
@@ -36,7 +35,7 @@ package flixel.system.render.genome2d
 			genome.onInitialized.addOnce(genomeInitializedHandler);
 			genome.init(config);
 			
-			startGameCallback = StartGameCallback;
+			updateCallback = UpdateCallback;
 		}
 		
 		private function genomeInitializedHandler():void
@@ -45,9 +44,8 @@ package flixel.system.render.genome2d
 			texture = GTextureFactory.createFromEmbedded("texture", TexturePNG);
 			
 			// Add a callback into the rendering pipeline
-			genome.onPreRender.add(preRenderHandler);
-			
-			startGameCallback();
+			// TODO: add docs explaining how it works. 
+			genome.onPreRender.add(updateCallback);
 		}
 		
 		private function preRenderHandler():void

--- a/src/flixel/system/render/genome2d/FlxGenome2DRender.as
+++ b/src/flixel/system/render/genome2d/FlxGenome2DRender.as
@@ -75,7 +75,7 @@ package flixel.system.render.genome2d
 		public function copyPixelsToBuffer(Camera:FlxCamera, sourceTexture:GTexture, sourceBitmapData:BitmapData, sourceRect:Rectangle, destPoint:Point, alphaBitmapData:BitmapData = null, alphaPoint:Point = null, mergeAlpha:Boolean = false):void
 		{
 			var context:IContext = genome.getContext();
-			context.drawSource(sourceTexture, sourceRect.x, sourceRect.y, sourceRect.width, sourceRect.height, destPoint.x * Camera.zoom + sourceRect.width, destPoint.y * Camera.zoom + sourceRect.height, Camera.zoom, Camera.zoom);
+			context.drawSource(sourceTexture, sourceRect.x, sourceRect.y, sourceRect.width, sourceRect.height, (destPoint.x + sourceRect.width/2) * Camera.zoom, (destPoint.y + sourceRect.height/2) * Camera.zoom, Camera.zoom, Camera.zoom);
 		}
 		
 		/**

--- a/src/flixel/system/render/genome2d/FlxGenome2DRender.as
+++ b/src/flixel/system/render/genome2d/FlxGenome2DRender.as
@@ -110,7 +110,14 @@ package flixel.system.render.genome2d
 			genome.onPreRender.add(updateCallback);
 		}
 		
-		public function draw(State:FlxState):void
+		/**
+		 * Performs a graphic step, rendering all elements into the screen. Flixel will invoke this method after
+		 * it has updated all game entities. This method *should not* be invoked directly since Flixel will do
+		 * it automatically at the right time.
+		 * 
+		 * @param	State	The state whose elements will be rendered into the screen.
+		 */
+		public function step(State:FlxState):void
 		{
 			var context:IContext = genome.getContext();
 			var l:uint = FlxG.cameras.length;
@@ -156,18 +163,20 @@ package flixel.system.render.genome2d
 		}
 		
 		/**
-		 * TODO: Render: add docs.
-		 * TODO: find a better name for this method.
+		 * Draw the source object into the screen with no stretching, rotation, or color effects. 
+		 * This method renders a rectangular area of a source image to a rectangular area of the same size
+		 * at the destination point of the informed destination.
 		 * 
-		 * @param	Camera
-		 * @param	sourceBitmapData
-		 * @param	sourceRect
-		 * @param	destPoint
-		 * @param	alphaBitmapData
-		 * @param	alphaPoint
-		 * @param	mergeAlpha
+		 * @param	Camera				The camera that is being rendered to the screen at the moment.
+		 * @param	sourceTexture		TODO: encapsulate it under FlxTexture.
+		 * @param	sourceBitmapData	TODO: encapsulate it under FlxTexture.
+		 * @param	sourceRect			A rectangle that defines the area of the source image to use as input.
+		 * @param	destPoint			The destination point that represents the upper-left corner of the rectangular area where the new pixels are placed.
+		 * @param	alphaBitmapData		A secondary, alpha BitmapData object source.
+		 * @param	alphaPoint			The point in the alpha BitmapData object source that corresponds to the upper-left corner of the sourceRect parameter.
+		 * @param	mergeAlpha			To use the alpha channel, set the value to true. To copy pixels with no alpha channel, set the value to <code>false</code>
 		 */
-		public function copyPixelsToBuffer(Camera:FlxCamera, sourceTexture:GTexture, sourceBitmapData:BitmapData, sourceRect:Rectangle, destPoint:Point, alphaBitmapData:BitmapData = null, alphaPoint:Point = null, mergeAlpha:Boolean = false):void
+		public function copyPixels(Camera:FlxCamera, sourceTexture:GTexture, sourceBitmapData:BitmapData, sourceRect:Rectangle, destPoint:Point, alphaBitmapData:BitmapData = null, alphaPoint:Point = null, mergeAlpha:Boolean = false):void
 		{
 			var context:IContext = genome.getContext();
 			
@@ -177,55 +186,49 @@ package flixel.system.render.genome2d
 		}
 		
 		/**
-		 * TODO: Render: add docs.
-		 * TODO: find a better name for this method.
+		 * Draws the source display object into the screen using transformations. You can specify matrix, colorTransform, 
+		 * blendMode, and a destination clipRect parameter to control how the rendering performs.
+		 * Optionally, you can specify whether the bitmap should be smoothed when scaled (this works only if the source object
+		 * is a BitmapData object).
 		 * 
-		 * @param	Camera
-		 * @param	source
-		 * @param	sourceRect
-		 * @param	matrix
-		 * @param	colorTransform
-		 * @param	blendMode
-		 * @param	clipRect
-		 * @param	smoothing
+		 * This method is an imitation of <code>BitmapData#draw()</code>.
+		 * 
+		 * @param	Camera				The camera that is being rendered to the screen at the moment.
+		 * @param	sourceTexture		TODO: encapsulate it under FlxTexture.
+		 * @param	source				TODO: encapsulate it under FlxTexture.
+		 * @param	sourceRect			A rectangle that defines the area of the source image to use as input.
+		 * @param	matrix				A Matrix object used to scale, rotate, or translate the coordinates of the input. It's <code>null</code> by default, meaning no transformation will be applied.
+		 * @param	colorTransform		A ColorTransform object used to adjust the color values of the input during rendering. It's <code>null</code> by default, meaning no transformation will be applied.
+		 * @param	blendMode			A string value, from the <code>flash.display.BlendMode</code> class, specifying the blend mode to be applied during rendering.
+		 * @param	clipRect			A Rectangle object that defines the area of the source object to draw. If <code>null</code> is provided (default), no clipping occurs and the entire source object is drawn.
+		 * @param	smoothing			A Boolean value that determines whether a the source object is smoothed when scaled or rotated, due to a scaling or rotation in the matrix parameter.
 		 */
-		public function drawToBuffer(Camera:FlxCamera, sourceTexture:GTexture, source:IBitmapDrawable, sourceRect:Rectangle, matrix:Matrix = null, colorTransform:ColorTransform = null, blendMode:String = null, clipRect:Rectangle = null, smoothing:Boolean = false):void
+		public function draw(Camera:FlxCamera, sourceTexture:GTexture, source:IBitmapDrawable, sourceRect:Rectangle, matrix:Matrix = null, colorTransform:ColorTransform = null, blendMode:String = null, clipRect:Rectangle = null, smoothing:Boolean = false):void
 		{
 			var context:IContext;
 			
-			if (sourceTexture == null && source != null)
-			{
-				drawToDebugBuffer(Camera, source, sourceRect, matrix, colorTransform, blendMode, clipRect, smoothing);
-			}
-			else
-			{
-				context = genome.getContext();
+			context = genome.getContext();
 
-				context.setBackgroundColor(Camera.bgColor);
-				context.setMaskRect(new Rectangle(Camera.x * Camera.zoom, Camera.y * Camera.zoom, Camera.width * Camera.zoom, Camera.height * Camera.zoom));
-				context.drawMatrixSource(sourceTexture, sourceRect.x, sourceRect.y, sourceRect.width, sourceRect.height, matrix.a * Camera.zoom, matrix.b * Camera.zoom, matrix.c * Camera.zoom, matrix.d * Camera.zoom, (matrix.tx + Camera.fxShakeOffset.x) * Camera.zoom, (matrix.ty + Camera.fxShakeOffset.y) * Camera.zoom);
-			}
+			context.setBackgroundColor(Camera.bgColor);
+			context.setMaskRect(new Rectangle(Camera.x * Camera.zoom, Camera.y * Camera.zoom, Camera.width * Camera.zoom, Camera.height * Camera.zoom));
+			context.drawMatrixSource(sourceTexture, sourceRect.x, sourceRect.y, sourceRect.width, sourceRect.height, matrix.a * Camera.zoom, matrix.b * Camera.zoom, matrix.c * Camera.zoom, matrix.d * Camera.zoom, (matrix.tx + Camera.fxShakeOffset.x) * Camera.zoom, (matrix.ty + Camera.fxShakeOffset.y) * Camera.zoom);
 		}
 		
 		/**
-		 * TODO: Rende: add docs.
+		 * Draws generic graphics to the screen using a blitting debug buffer. Highly changing graphics, such as debug lines, cannot be uploaed to
+		 * the GPU every frame, so the render provides this method that renders a source object to a special buffer using blitting.
+		 * This method should be used when performance is not a concern, e.g. when debug overlays are being rendered.
 		 * 
-		 * @param	Camera
-		 * @param	source
-		 * @param	sourceRect
-		 * @param	matrix
-		 * @param	colorTransform
-		 * @param	blendMode
-		 * @param	clipRect
-		 * @param	smoothing
+		 * @param	Camera				The camera that is being rendered to the screen at the moment.
+		 * @param	source				The display object or BitmapData object to draw to the BitmapData object.
 		 */
-		private function drawToDebugBuffer(Camera:FlxCamera, source:IBitmapDrawable, sourceRect:Rectangle, matrix:Matrix = null, colorTransform:ColorTransform = null, blendMode:String = null, clipRect:Rectangle = null, smoothing:Boolean = false):void
+		public function drawDebug(Camera:FlxCamera, source:IBitmapDrawable):void
 		{
 			// TODO: improve this line
 			m.createBox(Camera.zoom, Camera.zoom);
 
 			debugBufferContainer.visible = true;
-			debugBuffer.draw(source, m, colorTransform, blendMode, clipRect, smoothing);
+			debugBuffer.draw(source, m);
 		}
 	}
 }

--- a/src/flixel/system/render/genome2d/FlxGenome2DRender.as
+++ b/src/flixel/system/render/genome2d/FlxGenome2DRender.as
@@ -83,9 +83,6 @@ package flixel.system.render.genome2d
 				texture = GTextureFactory.createFromBitmapData("texture2", sourceBitmapData);
 			}
 			context.draw(texture, destPoint.x * Camera.zoom, destPoint.y * Camera.zoom, Camera.zoom, Camera.zoom);
-			
-			//context.drawSource(texture, sourceX, sourceY, sourceWidth, sourceHeight, x, y, scaleX, scaleY, rotation, red, green, blue, alpha, blendMode, filter);
-			//FlxG.log("HOW?!");
 		}
 		
 		/**
@@ -105,12 +102,10 @@ package flixel.system.render.genome2d
 			var context:IContext = genome.getContext();
 			
 			if(texture == null) {
-				texture = GTextureFactory.createFromEmbedded("texture2", TexturePNG);
+				texture = GTextureFactory.createFromBitmapData("texture2", source as BitmapData);
 			}
-			context.draw(texture, 10, 10);
-			
-			//context.drawSource(texture, sourceX, sourceY, sourceWidth, sourceHeight, x, y, scaleX, scaleY, rotation, red, green, blue, alpha, blendMode, filter);
-			FlxG.log("here?");
+
+			context.drawMatrix(texture, matrix.a * Camera.zoom, matrix.b * Camera.zoom, matrix.c * Camera.zoom, matrix.d * Camera.zoom, matrix.tx * Camera.zoom, matrix.ty * Camera.zoom);
 		}
 	}
 }

--- a/src/flixel/system/render/genome2d/FlxGenome2DRender.as
+++ b/src/flixel/system/render/genome2d/FlxGenome2DRender.as
@@ -21,6 +21,7 @@ package flixel.system.render.genome2d
 	import flixel.FlxGame;
 	import flixel.FlxState;
 	import flixel.system.render.FlxRender;
+	import flixel.system.render.FlxTexture;
 	
 	/**
 	 * A GPU render based on Genome2D (http://genome2d.com). It uses hardware acceleration (GPU) to draw elements into the
@@ -226,19 +227,19 @@ package flixel.system.render.genome2d
 		 * at the destination point of the informed destination.
 		 * 
 		 * @param	Camera				The camera that is being rendered to the screen at the moment.
-		 * @param	SourceTexture		TODO: encapsulate it under FlxTexture.
-		 * @param	SourceBitmapData	TODO: encapsulate it under FlxTexture.
+		 * @param	SourceTexture		A GPU texture representing the graphic to be rendered.
+		 * @param	SourceBitmapData	A bitmapData representing the graphic to be rendered.
 		 * @param	SourceRect			A rectangle that defines the area of the source image to use as input.
 		 * @param	DestPoint			The destination point that represents the upper-left corner of the rectangular area where the new pixels are placed.
 		 * @param	AlphaBitmapData		A secondary, alpha BitmapData object source.
 		 * @param	AlphaPoint			The point in the alpha BitmapData object source that corresponds to the upper-left corner of the SourceRect parameter.
 		 * @param	MergeAlpha			To use the alpha channel, set the value to true. To copy pixels with no alpha channel, set the value to <code>false</code>
 		 */
-		public function copyPixels(Camera:FlxCamera, SourceTexture:GTexture, SourceBitmapData:BitmapData, SourceRect:Rectangle, DestPoint:Point, AlphaBitmapData:BitmapData = null, AlphaPoint:Point = null, MergeAlpha:Boolean = false):void
+		public function copyPixels(Camera:FlxCamera, SourceTexture:FlxTexture, SourceBitmapData:BitmapData, SourceRect:Rectangle, DestPoint:Point, AlphaBitmapData:BitmapData = null, AlphaPoint:Point = null, MergeAlpha:Boolean = false):void
 		{
 			var context:IContext = _genome.getContext();
 			
-			context.drawSource(	SourceTexture,
+			context.drawSource(	SourceTexture.gpuData,
 								SourceRect.x,
 								SourceRect.y,
 								SourceRect.width,
@@ -258,8 +259,8 @@ package flixel.system.render.genome2d
 		 * This method is an imitation of <code>BitmapData#draw()</code>.
 		 * 
 		 * @param	Camera				The camera that is being rendered to the screen at the moment.
-		 * @param	SourceTexture		TODO: encapsulate it under FlxTexture.
-		 * @param	Source				TODO: encapsulate it under FlxTexture.
+		 * @param	SourceTexture		A GPU texture representing the graphic to be rendered.
+		 * @param	Source				A bitmapData representing the graphic to be rendered.
 		 * @param	SourceRect			A rectangle that defines the area of the source image to use as input.
 		 * @param	TransMatrix			A Matrix object used to scale, rotate, or translate the coordinates of the input. It's <code>null</code> by default, meaning no transformation will be applied.
 		 * @param	ColorTrans			A ColorTransform object used to adjust the color values of the input during rendering. It's <code>null</code> by default, meaning no transformation will be applied.
@@ -267,11 +268,11 @@ package flixel.system.render.genome2d
 		 * @param	ClipRect			A Rectangle object that defines the area of the source object to draw. If <code>null</code> is provided (default), no clipping occurs and the entire source object is drawn.
 		 * @param	Smoothing			A Boolean value that determines whether a the source object is smoothed when scaled or rotated, due to a scaling or rotation in the Matrix parameter.
 		 */
-		public function draw(Camera:FlxCamera, SourceTexture:GTexture, Source:IBitmapDrawable, SourceRect:Rectangle, TransMatrix:Matrix = null, ColorTrans:ColorTransform = null, BlendMode:String = null, ClipRect:Rectangle = null, Smoothing:Boolean = false):void
+		public function draw(Camera:FlxCamera, SourceTexture:FlxTexture, Source:IBitmapDrawable, SourceRect:Rectangle, TransMatrix:Matrix = null, ColorTrans:ColorTransform = null, BlendMode:String = null, ClipRect:Rectangle = null, Smoothing:Boolean = false):void
 		{
 			var context:IContext = _genome.getContext();
 
-			context.drawMatrixSource(SourceTexture,
+			context.drawMatrixSource(SourceTexture.gpuData,
 									 SourceRect.x,
 									 SourceRect.y,
 									 SourceRect.width,

--- a/src/flixel/system/render/genome2d/FlxGenome2DRender.as
+++ b/src/flixel/system/render/genome2d/FlxGenome2DRender.as
@@ -5,7 +5,13 @@ package flixel.system.render.genome2d
 	import com.genome2d.Genome2D;
 	import com.genome2d.textures.factories.GTextureFactory;
 	import com.genome2d.textures.GTexture;
+	import flash.display.BitmapData;
+	import flash.display.IBitmapDrawable;
+	import flash.geom.ColorTransform;
+	import flash.geom.Matrix;
+	import flash.geom.Point;
 	import flash.geom.Rectangle;
+	import flixel.FlxCamera;
 	import flixel.FlxG;
 	import flixel.FlxGame;
 	import flixel.FlxState;
@@ -42,7 +48,7 @@ package flixel.system.render.genome2d
 		private function genomeInitializedHandler():void
 		{
 			// We will create a single texture from an embedded bitmap
-			texture = GTextureFactory.createFromEmbedded("texture", TexturePNG);
+			//texture = GTextureFactory.createFromEmbedded("texture", TexturePNG);
 			
 			// Add a callback into the rendering pipeline
 			// TODO: add docs explaining how it works. 
@@ -51,9 +57,60 @@ package flixel.system.render.genome2d
 		
 		public function draw(State:FlxState):void
 		{
-			var context:IContext = genome.getContext();
-			context.draw(texture, 50, 50);
+			//var context:IContext = genome.getContext();
+			//context.draw(texture, 50, 50);
 			//FlxG.log("working?" + FlxG.random.float());
+			State.draw();
+		}
+		
+		/**
+		 * TODO: Render: add docs.
+		 * TODO: find a better name for this method.
+		 * 
+		 * @param	Camera
+		 * @param	sourceBitmapData
+		 * @param	sourceRect
+		 * @param	destPoint
+		 * @param	alphaBitmapData
+		 * @param	alphaPoint
+		 * @param	mergeAlpha
+		 */
+		public function copyPixelsToBuffer(Camera:FlxCamera, sourceBitmapData:BitmapData, sourceRect:Rectangle, destPoint:Point, alphaBitmapData:BitmapData = null, alphaPoint:Point = null, mergeAlpha:Boolean = false):void
+		{
+			var context:IContext = genome.getContext();
+			
+			if(texture == null) {
+				texture = GTextureFactory.createFromBitmapData("texture2", sourceBitmapData);
+			}
+			context.draw(texture, destPoint.x * Camera.zoom, destPoint.y * Camera.zoom, Camera.zoom, Camera.zoom);
+			
+			//context.drawSource(texture, sourceX, sourceY, sourceWidth, sourceHeight, x, y, scaleX, scaleY, rotation, red, green, blue, alpha, blendMode, filter);
+			//FlxG.log("HOW?!");
+		}
+		
+		/**
+		 * TODO: Render: add docs.
+		 * TODO: find a better name for this method.
+		 * 
+		 * @param	Camera
+		 * @param	source
+		 * @param	matrix
+		 * @param	colorTransform
+		 * @param	blendMode
+		 * @param	clipRect
+		 * @param	smoothing
+		 */
+		public function drawToBuffer(Camera:FlxCamera, source:IBitmapDrawable, matrix:Matrix = null, colorTransform:ColorTransform = null, blendMode:String = null, clipRect:Rectangle = null, smoothing:Boolean = false):void
+		{
+			var context:IContext = genome.getContext();
+			
+			if(texture == null) {
+				texture = GTextureFactory.createFromEmbedded("texture2", TexturePNG);
+			}
+			context.draw(texture, 10, 10);
+			
+			//context.drawSource(texture, sourceX, sourceY, sourceWidth, sourceHeight, x, y, scaleX, scaleY, rotation, red, green, blue, alpha, blendMode, filter);
+			FlxG.log("here?");
 		}
 	}
 }

--- a/src/flixel/system/render/genome2d/FlxGenome2DRender.as
+++ b/src/flixel/system/render/genome2d/FlxGenome2DRender.as
@@ -191,8 +191,9 @@ package flixel.system.render.genome2d
 				renderPosY = (camera.fxShakeOffset.y + camera.y + camera.height / 2) * camera.zoom;
 				
 				// Render the camera background. It's the equivalent of calling camera.fill() in the blitting render.
+				// TODO: make camera#color a FlxColor and read it using camera.color.r, camera.color.b, etc.
 				context.setBackgroundColor(camera.bgColor);
-				context.draw(camera.bgTexture.gpuData, renderPosX, renderPosY, camera.zoom, camera.zoom, 0, camera.colorTransform.redMultiplier, camera.colorTransform.greenMultiplier, camera.colorTransform.blueMultiplier);
+				context.draw(camera.bgTexture.gpuData, renderPosX, renderPosY, camera.zoom, camera.zoom, 0, ((camera.color >> 16) & 0xFF) / 255.0, ((camera.color >> 8) & 0xFF) / 255.0, (camera.color & 0xFF) / 255.0);
 				
 				// Iterate over every entry in the state, rendering it.
 				j = 0;
@@ -217,7 +218,7 @@ package flixel.system.render.genome2d
 					renderPosX = (camera.x + camera.width / 2) * camera.zoom;
 					renderPosY = (camera.y + camera.height / 2) * camera.zoom;
 					
-					// TODO: make camera's fxColorAcumulator a FlxColor and read it using camera.fxColor.r, camera.fxColor.b, etc.
+					// TODO: make camera's fxColorAcumulator a FlxColor and read it using camera.fxColorAcumulator.r, camera.fxColorAcumulator.b, etc.
 					context.draw(_textureFX, renderPosX, renderPosY, camera.zoom, camera.zoom, 0, ((camera.fxColorAcumulator >> 16) & 0xFF) / 255.0, ((camera.fxColorAcumulator >> 8) & 0xFF) / 255.0, (camera.fxColorAcumulator & 0xFF) / 255.0, ((camera.fxColorAcumulator >> 24) & 0xFF) / 255.0, GBlendMode.NORMAL);
 				}
 				

--- a/src/flixel/system/render/genome2d/FlxGenome2DRender.as
+++ b/src/flixel/system/render/genome2d/FlxGenome2DRender.as
@@ -136,7 +136,7 @@ package flixel.system.render.genome2d
 					continue;
 					
 				context.setMaskRect(new Rectangle(camera.x * camera.zoom, camera.y * camera.zoom, camera.width * camera.zoom, camera.height * camera.zoom)); // TODO: Render: improve rectangle allocation
-				context.draw(camera.texture, (camera.fxShakeOffset.x + camera.x + camera.width / 2) * camera.zoom, (camera.fxShakeOffset.y + camera.y + camera.height / 2) * camera.zoom, camera.zoom, camera.zoom, 0, camera.colorTransform.redMultiplier, camera.colorTransform.greenMultiplier, camera.colorTransform.blueMultiplier);
+				context.draw(camera.bgTexture.gpuData, (camera.fxShakeOffset.x + camera.x + camera.width / 2) * camera.zoom, (camera.fxShakeOffset.y + camera.y + camera.height / 2) * camera.zoom, camera.zoom, camera.zoom, 0, camera.colorTransform.redMultiplier, camera.colorTransform.greenMultiplier, camera.colorTransform.blueMultiplier);
 				
 				var j:uint = 0;
 				while (j < State.members.length)

--- a/src/flixel/system/render/genome2d/FlxGenome2DRender.as
+++ b/src/flixel/system/render/genome2d/FlxGenome2DRender.as
@@ -1,0 +1,60 @@
+package flixel.system.render.genome2d 
+{
+	import com.genome2d.context.GContextConfig;
+	import com.genome2d.context.IContext;
+	import com.genome2d.Genome2D;
+	import com.genome2d.textures.factories.GTextureFactory;
+	import com.genome2d.textures.GTexture;
+	import flash.geom.Rectangle;
+	import flixel.FlxG;
+	import flixel.FlxGame;
+	import flixel.system.render.FlxRender;
+	
+	/**
+	 * TODO: add docs
+	 * 
+	 * Tutorial from: http://blog.flash-core.com/?p=3132
+	 * 
+	 * @author Dovyski
+	 */
+	public class FlxGenome2DRender extends FlxRender
+	{
+		[Embed(source="../../../../../../../Testing/src/Ground.png")] private var TexturePNG:Class;
+		
+		private var texture:GTexture;
+		private var genome:Genome2D;
+		private var startGameCallback:Function;
+		
+		public function FlxGenome2DRender(Game:FlxGame, StartGameCallback:Function) 
+		{
+			super(Game, StartGameCallback);
+			
+			var config:GContextConfig = new GContextConfig(Game.stage, new Rectangle(0,0,Game.stage.stageWidth,Game.stage.stageHeight));
+			 
+			// Initialize Genome2D
+			genome = Genome2D.getInstance();
+			genome.onInitialized.addOnce(genomeInitializedHandler);
+			genome.init(config);
+			
+			startGameCallback = StartGameCallback;
+		}
+		
+		private function genomeInitializedHandler():void
+		{
+			// We will create a single texture from an embedded bitmap
+			texture = GTextureFactory.createFromEmbedded("texture", TexturePNG);
+			
+			// Add a callback into the rendering pipeline
+			genome.onPreRender.add(preRenderHandler);
+			
+			startGameCallback();
+		}
+		
+		private function preRenderHandler():void
+		{
+			var context:IContext = genome.getContext();
+			context.draw(texture, 50, 50);
+			//FlxG.log("working?" + FlxG.random.float());
+		}
+	}
+}

--- a/src/flixel/system/render/genome2d/FlxGenome2DRender.as
+++ b/src/flixel/system/render/genome2d/FlxGenome2DRender.as
@@ -94,7 +94,7 @@ package flixel.system.render.genome2d
 			// Initialize the debug buffer, used to draw things using blitting when GPU textures
 			// are not available (e.g. dynamic debug lines).
 			
-			_debugBuffer = new BitmapData(Game.stage.stageWidth, Game.stage.stageHeight, true, 0xFF000000);
+			_debugBuffer = new BitmapData(Game.stage.stageWidth, Game.stage.stageHeight, true, 0x00000000);
 			_debugBufferContainer = new Bitmap(_debugBuffer);
 			
 			Game.parent.addChild(_debugBufferContainer);
@@ -155,8 +155,15 @@ package flixel.system.render.genome2d
 			var renderPosX :Number;
 			var renderPosY :Number;
 			
-			// TODO: improve this! it's being called for every draw call, but it is required only when the debug buffer is in use.
-			_debugBuffer.fillRect(_config.viewRect, 0x00000000);
+			if (_debugBufferContainer.visible)
+			{
+				// Debug buffer is active (visible), clear it before drawing anything.
+				_debugBuffer.fillRect(_config.viewRect, 0x00000000);
+				
+				// Disable the debug buffer for this frame. If someone calls drawDebug()
+				// during the rendering step, the debugBuffer will become visible again.
+				_debugBufferContainer.visible = false;
+			}
 			
 			while(i < totalCameras)
 			{
@@ -285,13 +292,12 @@ package flixel.system.render.genome2d
 		 * @param	Camera				The camera that is being rendered to the screen at the moment.
 		 * @param	source				The display object or BitmapData object to draw to the BitmapData object.
 		 */
-		public function drawDebug(Camera:FlxCamera, source:IBitmapDrawable):void
+		public function drawDebug(Camera:FlxCamera, Source:IBitmapDrawable):void
 		{
-			// TODO: improve this line
-			_matrix.createBox(Camera.zoom, Camera.zoom);
+			_matrix.createBox(Camera.zoom, Camera.zoom, 0, 1, 1);
 
 			_debugBufferContainer.visible = true;
-			_debugBuffer.draw(source, _matrix);
+			_debugBuffer.draw(Source, _matrix);
 		}
 	}
 }

--- a/src/flixel/tile/FlxTilemap.as
+++ b/src/flixel/tile/FlxTilemap.as
@@ -381,7 +381,7 @@ package flixel.tile
 					_flashRect = _rects[columnIndex] as Rectangle;
 					if(_flashRect != null)
 					{
-						Buffer.pixels.copyPixels(_tiles,_flashRect,_flashPoint,null,null,true);
+						Buffer.enqueue(_flashRect,_flashPoint);
 						if(FlxG.visualDebug && !ignoreDrawDebug)
 						{
 							tile = _tileObjects[_data[columnIndex]];
@@ -393,7 +393,7 @@ package flixel.tile
 									debugTile = _debugTilePartial; //pink
 								else
 									debugTile = _debugTileSolid; //green
-								Buffer.pixels.copyPixels(debugTile,_debugRect,_flashPoint,null,null,true);
+								//Buffer.pixels.copyPixels(debugTile,_debugRect,_flashPoint,null,null,true); TODO: Render: implement this debug buffer
 							}
 						}
 					}
@@ -431,7 +431,7 @@ package flixel.tile
 			{
 				camera = cameras[i];
 				if(_buffers[i] == null)
-					_buffers[i] = new FlxTilemapBuffer(_tileWidth,_tileHeight,widthInTiles,heightInTiles,camera);
+					_buffers[i] = new FlxTilemapBuffer(_tiles,_tileWidth,_tileHeight,widthInTiles,heightInTiles,camera);
 				buffer = _buffers[i++] as FlxTilemapBuffer;
 				if(!buffer.dirty)
 				{

--- a/src/flixel/tile/FlxTilemap.as
+++ b/src/flixel/tile/FlxTilemap.as
@@ -143,6 +143,7 @@ package flixel.tile
 			immovable = true;
 			moves = false;
 			
+			cameras = null;
 			_debugTileNotSolid = null;
 			_debugTilePartial = null;
 			_debugTileSolid = null;

--- a/src/flixel/tile/FlxTilemap.as
+++ b/src/flixel/tile/FlxTilemap.as
@@ -1,12 +1,11 @@
 package flixel.tile
 {
-	import com.genome2d.textures.factories.GTextureFactory;
 	import flixel.FlxBasic;
 	import flixel.FlxCamera;
 	import flixel.FlxG;
 	import flixel.FlxGroup;
 	import flixel.FlxObject;
-	import flixel.system.render.blitting.FlxBlittingRender;
+	import flixel.system.render.FlxTexture;
 	
 	import flixel.util.FlxMath;
 	import flixel.util.FlxPath;
@@ -108,19 +107,16 @@ package flixel.tile
 		
 		/**
 		 * Internal, used for rendering the debug bounding box display.
-		 * TODO: Redner: change property type to FlxTexture.
 		 */
-		protected var _debugTileNotSolid:Object;
+		protected var _debugTileNotSolid:FlxTexture;
 		/**
 		 * Internal, used for rendering the debug bounding box display.
-		 * TODO: Redner: change property type to FlxTexture.
 		 */
-		protected var _debugTilePartial:Object;
+		protected var _debugTilePartial:FlxTexture;
 		/**
 		 * Internal, used for rendering the debug bounding box display.
-		 * TODO: Redner: change property type to FlxTexture.
 		 */
-		protected var _debugTileSolid:Object;
+		protected var _debugTileSolid:FlxTexture;
 		/**
 		 * Internal, used for rendering the debug bounding box display.
 		 */
@@ -313,12 +309,10 @@ package flixel.tile
 		/**
 		 * Internal function to clean up the map loading code.
 		 * Just generates a wireframe box the size of a tile with the specified color.
-		 * 
-		 * TODO: Render: change return type to FlxTexture
 		 */
-		protected function makeDebugTile(Color:uint):Object
+		protected function makeDebugTile(Color:uint):FlxTexture
 		{
-			var tileTexture:Object = {'bitmap': null, 'texture': null};// TODO: Render: change to FlxTexture
+			var tileTexture:FlxTexture = new FlxTexture();
 			var debugTile:BitmapData = new BitmapData(_tileWidth,_tileHeight,true,0);
 
 			var gfx:Graphics = FlxG.flashGfx;
@@ -331,12 +325,7 @@ package flixel.tile
 			gfx.lineTo(0,0);
 			
 			debugTile.draw(FlxG.flashGfxSprite);
-			tileTexture.bitmapData = debugTile;
-			
-			if (!(FlxG.render is FlxBlittingRender))
-			{
-				tileTexture.texture = GTextureFactory.createFromBitmapData("debugTile" + Math.random(), debugTile);
-			}
+			tileTexture.setBitmapData(debugTile);
 			
 			return tileTexture;
 		}
@@ -393,7 +382,7 @@ package flixel.tile
 			var column:uint;
 			var columnIndex:uint;
 			var tile:FlxTile;
-			var debugTile:Object; // TODO: Render: change to FlxTexture
+			var debugTile:FlxTexture;
 			while(row < screenRows)
 			{
 				columnIndex = rowIndex;

--- a/src/flixel/tile/FlxTilemap.as
+++ b/src/flixel/tile/FlxTilemap.as
@@ -1,10 +1,12 @@
 package flixel.tile
 {
+	import com.genome2d.textures.factories.GTextureFactory;
 	import flixel.FlxBasic;
 	import flixel.FlxCamera;
 	import flixel.FlxG;
 	import flixel.FlxGroup;
 	import flixel.FlxObject;
+	import flixel.system.render.blitting.FlxBlittingRender;
 	
 	import flixel.util.FlxMath;
 	import flixel.util.FlxPath;
@@ -106,16 +108,19 @@ package flixel.tile
 		
 		/**
 		 * Internal, used for rendering the debug bounding box display.
+		 * TODO: Redner: change property type to FlxTexture.
 		 */
-		protected var _debugTileNotSolid:BitmapData;
+		protected var _debugTileNotSolid:Object;
 		/**
 		 * Internal, used for rendering the debug bounding box display.
+		 * TODO: Redner: change property type to FlxTexture.
 		 */
-		protected var _debugTilePartial:BitmapData;
+		protected var _debugTilePartial:Object;
 		/**
 		 * Internal, used for rendering the debug bounding box display.
+		 * TODO: Redner: change property type to FlxTexture.
 		 */
-		protected var _debugTileSolid:BitmapData;
+		protected var _debugTileSolid:Object;
 		/**
 		 * Internal, used for rendering the debug bounding box display.
 		 */
@@ -308,9 +313,12 @@ package flixel.tile
 		/**
 		 * Internal function to clean up the map loading code.
 		 * Just generates a wireframe box the size of a tile with the specified color.
+		 * 
+		 * TODO: Render: change return type to FlxTexture
 		 */
-		protected function makeDebugTile(Color:uint):BitmapData
+		protected function makeDebugTile(Color:uint):Object
 		{
+			var tileTexture:Object = {'bitmap': null, 'texture': null};// TODO: Render: change to FlxTexture
 			var debugTile:BitmapData = new BitmapData(_tileWidth,_tileHeight,true,0);
 
 			var gfx:Graphics = FlxG.flashGfx;
@@ -323,7 +331,14 @@ package flixel.tile
 			gfx.lineTo(0,0);
 			
 			debugTile.draw(FlxG.flashGfxSprite);
-			return debugTile;
+			tileTexture.bitmapData = debugTile;
+			
+			if (!(FlxG.render is FlxBlittingRender))
+			{
+				tileTexture.texture = GTextureFactory.createFromBitmapData("debugTile" + Math.random(), debugTile);
+			}
+			
+			return tileTexture;
 		}
 		
 		/**
@@ -378,7 +393,7 @@ package flixel.tile
 			var column:uint;
 			var columnIndex:uint;
 			var tile:FlxTile;
-			var debugTile:BitmapData;
+			var debugTile:Object; // TODO: Render: change to FlxTexture
 			while(row < screenRows)
 			{
 				columnIndex = rowIndex;
@@ -401,7 +416,8 @@ package flixel.tile
 									debugTile = _debugTilePartial; //pink
 								else
 									debugTile = _debugTileSolid; //green
-								//Buffer.pixels.copyPixels(debugTile,_debugRect,_flashPoint,null,null,true); TODO: Render: implement this debug buffer
+
+								Buffer.enqueue(_debugRect, _flashPoint, debugTile);
 							}
 						}
 					}

--- a/src/flixel/tile/FlxTilemapBuffer.as
+++ b/src/flixel/tile/FlxTilemapBuffer.as
@@ -113,7 +113,7 @@ package flixel.tile
 		 */
 		public function draw(Camera:FlxCamera,FlashPoint:Point):void
 		{
-			Camera.buffer.copyPixels(_pixels,_flashRect,FlashPoint,null,null,true);
+			FlxG.render.copyPixelsToBuffer(Camera, _pixels,_flashRect,FlashPoint,null,null,true);
 		}
 	}
 }

--- a/src/flixel/tile/FlxTilemapBuffer.as
+++ b/src/flixel/tile/FlxTilemapBuffer.as
@@ -95,7 +95,7 @@ package flixel.tile
 			_queue = new Array(l);
 			while (i < l)
 			{
-				_queue[i++] = { 'flashRect': new Rectangle(), 'flashPoint': new Point() };
+				_queue[i++] = { 'flashRect': new Rectangle(), 'flashPoint': new Point(), 'texture': null };
 			}
 			_queueSize = 0;
 			
@@ -133,10 +133,11 @@ package flixel.tile
 		
 		/**
 		 * Read-only, nab the actual buffer <code>BitmapData</code> object.
+		 * TODO: Render: change Texture:Object to Texture:FlxTexture
 		 * 
 		 * @return	The buffer bitmap data.
 		 */
-		public function enqueue(FlashRect:Rectangle, FlashPoint:Point):void
+		public function enqueue(FlashRect:Rectangle, FlashPoint:Point, Texture:Object = null):void
 		{
 			_queue[_queueSize].flashRect.x = FlashRect.x;
 			_queue[_queueSize].flashRect.y = FlashRect.y;
@@ -145,6 +146,8 @@ package flixel.tile
 			
 			_queue[_queueSize].flashPoint.x = FlashPoint.x;
 			_queue[_queueSize].flashPoint.y = FlashPoint.y;
+			
+			_queue[_queueSize].texture = Texture;
 			
 			_queueSize++;
 		}
@@ -164,7 +167,7 @@ package flixel.tile
 				_point.x = FlashPoint.x + _queue[i].flashPoint.x;
 				_point.y = FlashPoint.y + _queue[i].flashPoint.y;
 				
-				FlxG.render.copyPixelsToBuffer(Camera, _texture, _tiles, _queue[i].flashRect, _point, null, null, true);
+				FlxG.render.copyPixelsToBuffer(Camera, _queue[i].texture ? _queue[i].texture.texture : _texture, _queue[i].texture ? _queue[i].texture.bitmapData : null, _queue[i].flashRect, _point, null, null, true);
 				
 				i++;
 			}

--- a/src/flixel/tile/FlxTilemapBuffer.as
+++ b/src/flixel/tile/FlxTilemapBuffer.as
@@ -188,7 +188,7 @@ package flixel.tile
 				texture = _queue[i].texture ? _queue[i].texture : _texture;
 				
 				// Render the queue entry
-				FlxG.render.copyPixels(Camera, texture.gpuData, texture.bitmapData, _queue[i].flashRect, _point, null, null, true);
+				FlxG.render.copyPixels(Camera, texture, texture.bitmapData, _queue[i].flashRect, _point, null, null, true);
 
 				i++;
 			}

--- a/src/flixel/tile/FlxTilemapBuffer.as
+++ b/src/flixel/tile/FlxTilemapBuffer.as
@@ -113,7 +113,7 @@ package flixel.tile
 		 */
 		public function draw(Camera:FlxCamera,FlashPoint:Point):void
 		{
-			FlxG.render.copyPixelsToBuffer(Camera, _pixels,_flashRect,FlashPoint,null,null,true);
+			FlxG.render.copyPixelsToBuffer(Camera, null, _pixels,_flashRect,FlashPoint,null,null,true);
 		}
 	}
 }

--- a/src/flixel/tile/FlxTilemapBuffer.as
+++ b/src/flixel/tile/FlxTilemapBuffer.as
@@ -167,7 +167,7 @@ package flixel.tile
 				_point.x = FlashPoint.x + _queue[i].flashPoint.x;
 				_point.y = FlashPoint.y + _queue[i].flashPoint.y;
 				
-				FlxG.render.copyPixelsToBuffer(Camera, _queue[i].texture ? _queue[i].texture.texture : _texture, _queue[i].texture ? _queue[i].texture.bitmapData : _tiles, _queue[i].flashRect, _point, null, null, true);
+				FlxG.render.copyPixels(Camera, _queue[i].texture ? _queue[i].texture.texture : _texture, _queue[i].texture ? _queue[i].texture.bitmapData : _tiles, _queue[i].flashRect, _point, null, null, true);
 				
 				i++;
 			}

--- a/src/flixel/tile/FlxTilemapBuffer.as
+++ b/src/flixel/tile/FlxTilemapBuffer.as
@@ -167,7 +167,7 @@ package flixel.tile
 				_point.x = FlashPoint.x + _queue[i].flashPoint.x;
 				_point.y = FlashPoint.y + _queue[i].flashPoint.y;
 				
-				FlxG.render.copyPixelsToBuffer(Camera, _queue[i].texture ? _queue[i].texture.texture : _texture, _queue[i].texture ? _queue[i].texture.bitmapData : null, _queue[i].flashRect, _point, null, null, true);
+				FlxG.render.copyPixelsToBuffer(Camera, _queue[i].texture ? _queue[i].texture.texture : _texture, _queue[i].texture ? _queue[i].texture.bitmapData : _tiles, _queue[i].flashRect, _point, null, null, true);
 				
 				i++;
 			}

--- a/src/flixel/ui/FlxButton.as
+++ b/src/flixel/ui/FlxButton.as
@@ -214,8 +214,7 @@ package flixel.ui
 			// (ignore checkbox behavior for now).
 			if(FlxG.mouse.visible)
 			{
-				if(cameras == null)
-					cameras = FlxG.cameras;
+				var cameras:Array = FlxG.cameras;
 				var camera:FlxCamera;
 				var i:uint = 0;
 				var l:uint = cameras.length;
@@ -280,15 +279,16 @@ package flixel.ui
 		
 		/**
 		 * Just draws the button graphic and text label to the screen.
+		 * 
+		 * @param	Camera	The camera where the object will draw itself to.
 		 */
-		override public function draw():void
+		override public function draw(Camera:FlxCamera):void
 		{
-			super.draw();
+			super.draw(Camera);
 			if(label != null)
 			{
 				label.scrollFactor = scrollFactor;
-				label.cameras = cameras;
-				label.draw();
+				label.draw(Camera);
 			}
 		}
 		

--- a/src/flixel/ui/FlxText.as
+++ b/src/flixel/ui/FlxText.as
@@ -287,7 +287,7 @@ package flixel.ui
 				framePixels = new BitmapData(_pixels.width,_pixels.height,true,0);
 			framePixels.copyPixels(_pixels,_flashRect,_flashPointZero);
 
-			// TODO: Render: add docs
+			// Upload the new bitmapData to the GPU if current render is GPU-based.
 			refreshTexture();
 		}
 		

--- a/src/flixel/ui/FlxText.as
+++ b/src/flixel/ui/FlxText.as
@@ -286,6 +286,9 @@ package flixel.ui
 			if((framePixels == null) || (framePixels.width != _pixels.width) || (framePixels.height != _pixels.height))
 				framePixels = new BitmapData(_pixels.width,_pixels.height,true,0);
 			framePixels.copyPixels(_pixels,_flashRect,_flashPointZero);
+
+			// TODO: Render: add docs
+			refreshTexture();
 		}
 		
 		/**

--- a/src/flixel/util/FlxPath.as
+++ b/src/flixel/util/FlxPath.as
@@ -271,7 +271,7 @@ package flixel.util
 			}
 			
 			//then stamp the path down onto the game buffer
-			FlxG.render.drawToBuffer(Camera, null, FlxG.flashGfxSprite, null);
+			FlxG.render.drawDebug(Camera, FlxG.flashGfxSprite);
 		}
 		
 		static public function get manager():DebugPathDisplay

--- a/src/flixel/util/FlxPath.as
+++ b/src/flixel/util/FlxPath.as
@@ -271,7 +271,7 @@ package flixel.util
 			}
 			
 			//then stamp the path down onto the game buffer
-			Camera.buffer.draw(FlxG.flashGfxSprite);
+			FlxG.render.drawToBuffer(Camera, FlxG.flashGfxSprite);
 		}
 		
 		static public function get manager():DebugPathDisplay

--- a/src/flixel/util/FlxPath.as
+++ b/src/flixel/util/FlxPath.as
@@ -271,7 +271,7 @@ package flixel.util
 			}
 			
 			//then stamp the path down onto the game buffer
-			FlxG.render.drawToBuffer(Camera, FlxG.flashGfxSprite);
+			FlxG.render.drawToBuffer(Camera, null, FlxG.flashGfxSprite, null);
 		}
 		
 		static public function get manager():DebugPathDisplay

--- a/src/flixel/util/FlxU.as
+++ b/src/flixel/util/FlxU.as
@@ -48,6 +48,35 @@ package flixel.util
 		{
 			return (((Alpha>1)?Alpha:(Alpha * 255)) & 0xFF) << 24 | (Red & 0xFF) << 16 | (Green & 0xFF) << 8 | (Blue & 0xFF);
 		}
+		
+		/**
+		 * Blend two ARGB colors togheter, creating a new one.
+		 * 
+		 * @param   ColorA  An ARGB color to be blended.
+		 * @param   ColorB  An ARGB color to be blended.
+		 * 
+		 * @return  The resulting blended color as a <code>uint</code>.
+		 */
+		static public function blendColors(ColorA:uint, ColorB:uint):uint
+		{
+			// Ideas from here: http://stackoverflow.com/a/3233351/29827
+			var aa:uint = (ColorA >> 24) & 0xFF;
+			var ar:uint = (ColorA >> 16) & 0xFF;
+			var ag:uint = (ColorA >> 8)  & 0xFF;
+			var ab:uint = (ColorA >> 0)  & 0xFF;
+			
+			var ba:uint = (ColorB >> 24) & 0xFF;
+			var br:uint = (ColorB >> 16) & 0xFF;
+			var bg:uint = (ColorB >> 8)  & 0xFF;
+			var bb:uint = (ColorB >> 0)  & 0xFF;
+			
+			var ra:uint = (aa + ba) & 0xFF;
+			var rr:uint = (ar + br) & 0xFF;
+			var rg:uint = (ag + bg) & 0xFF;
+			var rb:uint = (ab + bb) & 0xFF;
+			
+			return (ra << 24) | (rr << 16) | (rg << 8) | rb;
+		}
 
 		/**
 		 * Generate a Flash <code>uint</code> color from HSB components.


### PR DESCRIPTION
I am really happy to issue this pull request. It makes Flixel Community GPU accelerated by using [Genome2D](genome2d.com) as a render.

This is the first step to bring Flixel to the GPU world, there is still room for improvement. Despite of that I've ran [some tests](http://www.as3gamegears.com/blog/making-flixel-community-gpu-accelerated/) and the new GPU render is way faster than the CPU blitting one.

I have tried to keep changes to a minimum, avoiding modifications that would break too many things. I think the only significant modification I've made that deeply changes the current API was the addition of a `Camera` param in `FlxBasic#draw()`, which is now `FlxBasic#draw(Camera:FlxCamera)`. There was no way I could think of to implement multiple cameras without that change.

Special thanks to @pshtif and @Beeblerox for helping making it happen!

Fix #90 
