### PR TITLE
Fix gpu render issues

### DIFF
--- a/src/flixel/FlxSprite.as
+++ b/src/flixel/FlxSprite.as
@@ -479,7 +479,7 @@ package flixel
 			{
 				_flashPoint.x = _point.x;
 				_flashPoint.y = _point.y;
-				FlxG.render.copyPixels(Camera,texture,framePixels,_flashRect,_flashPoint,null,null,true);
+				FlxG.render.copyPixels(Camera,texture,framePixels,_flashRect,_flashPoint,_colorTransform,null,null,true);
 			}
 			else //Advanced render
 			{
@@ -492,7 +492,7 @@ package flixel
 				if((angle != 0) && (_bakedRotation <= 0))
 					_matrix.rotate(angle * 0.017453293);
 				_matrix.translate(_point.x+origin.x,_point.y+origin.y);
-				FlxG.render.draw(Camera,texture,framePixels,_flashRect,_matrix,null,blend,null,antialiasing);
+				FlxG.render.draw(Camera,texture,framePixels,_flashRect,_matrix,_colorTransform,blend,null,antialiasing);
 			}
 			
 			_VISIBLECOUNT++;

--- a/src/flixel/system/render/FlxRender.as
+++ b/src/flixel/system/render/FlxRender.as
@@ -60,11 +60,12 @@ package flixel.system.render
 		 * @param	SourceBitmapData	A bitmapData representing the graphic to be rendered.
 		 * @param	SourceRect			A rectangle that defines the area of the source image to use as input.
 		 * @param	DestPoint			The destination point that represents the upper-left corner of the rectangular area where the new pixels are placed.
+		 * @param	ColorTrans			A ColorTransform object used to adjust the color values of the input during rendering. It's <code>null</code> by default, meaning no transformation will be applied.
 		 * @param	AlphaBitmapData		A secondary, alpha BitmapData object source.
 		 * @param	AlphaPoint			The point in the alpha BitmapData object source that corresponds to the upper-left corner of the SourceRect parameter.
 		 * @param	MergeAlpha			To use the alpha channel, set the value to true. To copy pixels with no alpha channel, set the value to <code>false</code>
 		 */
-		function copyPixels(Camera:FlxCamera, SourceTexture:FlxTexture, SourceBitmapData:BitmapData, SourceRect:Rectangle, DestPoint:Point, AlphaBitmapData:BitmapData = null, AlphaPoint:Point = null, MergeAlpha:Boolean = false):void;
+		function copyPixels(Camera:FlxCamera, SourceTexture:FlxTexture, SourceBitmapData:BitmapData, SourceRect:Rectangle, DestPoint:Point, ColorTrans:ColorTransform = null, AlphaBitmapData:BitmapData = null, AlphaPoint:Point = null, MergeAlpha:Boolean = false):void;
 		
 		/**
 		 * Draws the source display object into the screen using transformations. You can specify matrix, colorTransform, 

--- a/src/flixel/system/render/blitting/FlxBlittingRender.as
+++ b/src/flixel/system/render/blitting/FlxBlittingRender.as
@@ -94,11 +94,12 @@ package flixel.system.render.blitting
 		 * @param	SourceBitmapData	A bitmapData representing the graphic to be rendered.
 		 * @param	SourceRect			A rectangle that defines the area of the source image to use as input.
 		 * @param	DestPoint			The destination point that represents the upper-left corner of the rectangular area where the new pixels are placed.
+		 * @param	ColorTrans			A ColorTransform object used to adjust the color values of the input during rendering. It's <code>null</code> by default, meaning no transformation will be applied.
 		 * @param	AlphaBitmapData		A secondary, alpha BitmapData object source.
 		 * @param	AlphaPoint			The point in the alpha BitmapData object source that corresponds to the upper-left corner of the SourceRect parameter.
 		 * @param	MergeAlpha			To use the alpha channel, set the value to true. To copy pixels with no alpha channel, set the value to <code>false</code>
 		 */
-		public function copyPixels(Camera:FlxCamera, SourceTexture:FlxTexture, SourceBitmapData:BitmapData, SourceRect:Rectangle, DestPoint:Point, AlphaBitmapData:BitmapData = null, AlphaPoint:Point = null, MergeAlpha:Boolean = false):void
+		public function copyPixels(Camera:FlxCamera, SourceTexture:FlxTexture, SourceBitmapData:BitmapData, SourceRect:Rectangle, DestPoint:Point, ColorTrans:ColorTransform = null, AlphaBitmapData:BitmapData = null, AlphaPoint:Point = null, MergeAlpha:Boolean = false):void
 		{
 			Camera.buffer.copyPixels(SourceBitmapData, SourceRect, DestPoint, AlphaBitmapData, AlphaPoint, MergeAlpha);
 		}

--- a/src/flixel/system/render/genome2d/FlxGenome2DRender.as
+++ b/src/flixel/system/render/genome2d/FlxGenome2DRender.as
@@ -237,11 +237,12 @@ package flixel.system.render.genome2d
 		 * @param	SourceBitmapData	A bitmapData representing the graphic to be rendered.
 		 * @param	SourceRect			A rectangle that defines the area of the source image to use as input.
 		 * @param	DestPoint			The destination point that represents the upper-left corner of the rectangular area where the new pixels are placed.
+		 * @param	ColorTrans			A ColorTransform object used to adjust the color values of the input during rendering. It's <code>null</code> by default, meaning no transformation will be applied.
 		 * @param	AlphaBitmapData		A secondary, alpha BitmapData object source.
 		 * @param	AlphaPoint			The point in the alpha BitmapData object source that corresponds to the upper-left corner of the SourceRect parameter.
 		 * @param	MergeAlpha			To use the alpha channel, set the value to true. To copy pixels with no alpha channel, set the value to <code>false</code>
 		 */
-		public function copyPixels(Camera:FlxCamera, SourceTexture:FlxTexture, SourceBitmapData:BitmapData, SourceRect:Rectangle, DestPoint:Point, AlphaBitmapData:BitmapData = null, AlphaPoint:Point = null, MergeAlpha:Boolean = false):void
+		public function copyPixels(Camera:FlxCamera, SourceTexture:FlxTexture, SourceBitmapData:BitmapData, SourceRect:Rectangle, DestPoint:Point, ColorTrans:ColorTransform = null, AlphaBitmapData:BitmapData = null, AlphaPoint:Point = null, MergeAlpha:Boolean = false):void
 		{
 			var context:IContext = _genome.getContext();
 			
@@ -255,7 +256,13 @@ package flixel.system.render.genome2d
 								(Camera.fxShakeOffset.x + Camera.x + DestPoint.x + SourceRect.width / 2) * Camera.zoom,
 								(Camera.fxShakeOffset.y + Camera.y + DestPoint.y + SourceRect.height / 2) * Camera.zoom,
 								Camera.zoom,
-								Camera.zoom);
+								Camera.zoom,
+								0,
+								ColorTrans ? ColorTrans.redMultiplier : 1, 
+								ColorTrans ? ColorTrans.greenMultiplier : 1, 
+								ColorTrans ? ColorTrans.blueMultiplier : 1, 
+								ColorTrans ? ColorTrans.alphaMultiplier : 1,
+								GBlendMode.NORMAL);
 		}
 		
 		/**
@@ -290,7 +297,12 @@ package flixel.system.render.genome2d
 									 TransMatrix.c * Camera.zoom,
 									 TransMatrix.d * Camera.zoom,
 									 (TransMatrix.tx + Camera.fxShakeOffset.x) * Camera.zoom,
-									 (TransMatrix.ty + Camera.fxShakeOffset.y) * Camera.zoom);
+									 (TransMatrix.ty + Camera.fxShakeOffset.y) * Camera.zoom,
+									 ColorTrans ? ColorTrans.redMultiplier : 1, 
+									 ColorTrans ? ColorTrans.greenMultiplier : 1, 
+									 ColorTrans ? ColorTrans.blueMultiplier : 1, 
+									 ColorTrans ? ColorTrans.alphaMultiplier : 1,
+									 GBlendMode.NORMAL);
 		}
 		
 		/**

--- a/src/flixel/system/render/genome2d/FlxGenome2DRender.as
+++ b/src/flixel/system/render/genome2d/FlxGenome2DRender.as
@@ -250,6 +250,8 @@ package flixel.system.render.genome2d
 								SourceRect.y,
 								SourceRect.width,
 								SourceRect.height,
+								0,
+								0,
 								(Camera.fxShakeOffset.x + Camera.x + DestPoint.x + SourceRect.width / 2) * Camera.zoom,
 								(Camera.fxShakeOffset.y + Camera.y + DestPoint.y + SourceRect.height / 2) * Camera.zoom,
 								Camera.zoom,

--- a/src/flixel/tile/FlxTilemapBuffer.as
+++ b/src/flixel/tile/FlxTilemapBuffer.as
@@ -188,7 +188,7 @@ package flixel.tile
 				texture = _queue[i].texture ? _queue[i].texture : _texture;
 				
 				// Render the queue entry
-				FlxG.render.copyPixels(Camera, texture, texture.bitmapData, _queue[i].flashRect, _point, null, null, true);
+				FlxG.render.copyPixels(Camera, texture, texture.bitmapData, _queue[i].flashRect, _point, null, null, null, true);
 
 				i++;
 			}

--- a/src/flixel/util/FlxU.as
+++ b/src/flixel/util/FlxU.as
@@ -52,12 +52,13 @@ package flixel.util
 		/**
 		 * Blend two ARGB colors togheter, creating a new one.
 		 * 
-		 * @param   ColorA  An ARGB color to be blended.
-		 * @param   ColorB  An ARGB color to be blended.
+		 * @param   ColorA  	An ARGB color to be blended.
+		 * @param   ColorB  	An ARGB color to be blended.
+		 * @param   BlendAlpha  A boolean that tells if the alpha channel of both colors should be used during the blend.
 		 * 
 		 * @return  The resulting blended color as a <code>uint</code>.
 		 */
-		static public function blendColors(ColorA:uint, ColorB:uint):uint
+		static public function blendColors(ColorA:uint, ColorB:uint, BlendAlpha:Boolean = true):uint
 		{
 			// Ideas from here: http://stackoverflow.com/a/3233351/29827
 			var aa:uint = (ColorA >> 24) & 0xFF;
@@ -70,10 +71,13 @@ package flixel.util
 			var bg:uint = (ColorB >> 8)  & 0xFF;
 			var bb:uint = (ColorB >> 0)  & 0xFF;
 			
+			var ablend:Number = BlendAlpha ? (aa / 255) : 1.0;
+			var bblend:Number = BlendAlpha ? (ba / 255) : 1.0;
+			
 			var ra:uint = (aa + ba) & 0xFF;
-			var rr:uint = (ar + br) & 0xFF;
-			var rg:uint = (ag + bg) & 0xFF;
-			var rb:uint = (ab + bb) & 0xFF;
+			var rr:uint = uint(ar * ablend + br * bblend) & 0xFF;
+			var rg:uint = uint(ag * ablend + bg * bblend) & 0xFF;
+			var rb:uint = uint(ab * ablend + bb * bblend) & 0xFF;
 			
 			return (ra << 24) | (rr << 16) | (rg << 8) | rb;
 		}


### PR DESCRIPTION
Fix several issues with the new GPU render, including a black screen (no rendering), problems with `FlxSprite#color`, `FlxG.flash()` and `FlxG.fade()`.

The GPU render now requires Genome2D 1.0.279 or above.
