### PR TITLE
FlxReplay - remove snail from email address

### DIFF
--- a/src/flixel/plugin/replay/FlxReplay.as
+++ b/src/flixel/plugin/replay/FlxReplay.as
@@ -17,7 +17,7 @@ package flixel.plugin.replay
 	 * 
 	 * @author	Adam Atomic
 	 * 
-	 * Adaptation by Fernando Bevilacqua (dovyski@gmail.com)
+	 * Adaptation by Fernando Bevilacqua (dovyski&#64;gmail.com)
 	 */
 	public class FlxReplay implements FlxPlugin
 	{


### PR DESCRIPTION
This single change makes it possible to compile ASDoc for me. I don't know if it's the end of problems with snails in email addresses but it's the only one I've stumbled over in the last few months.

ASDoc tries too hard to read the snail as a tag. You have to replace it with the entity encoding or ASDoc experiences a fatal error.

There are still errors. They were mentioned in #228 .
