### PR TITLE
Implement ObjectPool design pattern for FlxQuadTree

### DIFF
--- a/src/flixel/FlxG.as
+++ b/src/flixel/FlxG.as
@@ -900,7 +900,8 @@ package flixel
 			if(ObjectOrGroup2 === ObjectOrGroup1)
 				ObjectOrGroup2 = null;
 			FlxQuadTree.divisions = FlxG.worldDivisions;
-			var quadTree:FlxQuadTree = new FlxQuadTree(FlxG.worldBounds.x,FlxG.worldBounds.y,FlxG.worldBounds.width,FlxG.worldBounds.height);
+			var quadTree:FlxQuadTree = FlxQuadTree.quadTreePool.getNew();
+			quadTree.init(FlxG.worldBounds.x, FlxG.worldBounds.y, FlxG.worldBounds.width, FlxG.worldBounds.height);
 			quadTree.load(ObjectOrGroup1,ObjectOrGroup2,NotifyCallback,ProcessCallback);
 			var result:Boolean = quadTree.execute();
 			quadTree.destroy();

--- a/src/flixel/util/FlxList.as
+++ b/src/flixel/util/FlxList.as
@@ -13,11 +13,17 @@ package flixel.util
 		 * Stores a reference to a <code>FlxObject</code>.
 		 */
 		public var object:FlxObject;
+
 		/**
 		 * Stores a reference to the next link in the list.
 		 */
 		public var next:FlxList;
-		
+
+		/**
+		 * A pool to prevent repeated <code>new</code> calls
+		 */
+		static public var listPool:FlxObjectPool = new FlxObjectPool(FlxList);
+
 		/**
 		 * Creates a new link, and sets <code>object</code> and <code>next</code> to <code>null</code>.
 		 */
@@ -36,6 +42,8 @@ package flixel.util
 			if(next != null)
 				next.destroy();
 			next = null;
+
+			listPool.disposeObject(this);
 		}
 	}
 }

--- a/src/flixel/util/FlxObjectPool.as
+++ b/src/flixel/util/FlxObjectPool.as
@@ -1,0 +1,41 @@
+package flixel.util
+{
+    /**
+     * TODO: Write documentation
+     *
+     * @author moly
+     * @author greysondn
+     */
+    public class FlxObjectPool
+    {
+        protected var _objects:Array;
+        protected var _objectClass:Class;
+        
+        public function FlxObjectPool(ObjectClass:Class)
+        {
+            _objectClass = ObjectClass;
+            _objects     = new Array();
+        }
+        
+        public function getNew():*
+        {
+            var object:* = null;
+            
+            if (_objects.length > 0)
+            {
+                object = _objects.pop();
+            }
+            else
+            {
+                object = new _objectClass();
+            }
+            
+            return object;
+        }
+        
+        public function disposeObject(OldObject:Object):void
+        {
+            _objects.push(OldObject);
+        }
+    }
+}


### PR DESCRIPTION
This is what I refer to as the @moly fixes, the changes requested more than a year ago in #107 and first attempted to patch in #169.

The major difference between now and back at #169 is... Well, moly's ObjectPool is a generic implementation of the design pattern, and a fairly elegant one at that. However, because this is Flixel, it's been renamed FlxObjectPool; and because of the organizational changes, I made it a public class and stuck in the `util` package.

Mostly, I referred to [the original commit's changes](https://github.com/FlixelCommunity/flixel/commit/f9fae274fae2631f1e35281c1976e41da147c994). There are some small differences - spacing, I guess I was OCD about curly braces at that time, etcetera - but otherwise the code is the same.

I have given this a once over test. Collisions still work and it compiles. That's all I can guarantee. I'm still dealing with [my own problems with the current codebase](https://github.com/FlixelCommunity/flixel/issues/227) that impede more exhaustive tests. I would recommend some testing, mostly to make sure that memory doesn't leak. It should actually rein in past memory problems, as well as give some speedup to physics calculations, but no promises.

For what it's worth, the first time this set of changes was attempted, it did result in significant speedups to the code's execution and was fine. It is only caution requesting testing.

I'm available for questioning and for changes needed in the pull.
